### PR TITLE
Parse `$DBUS_SESSION_BUS_ADDRESS` better

### DIFF
--- a/lib/dbus_client.dart
+++ b/lib/dbus_client.dart
@@ -1099,10 +1099,17 @@ class DBusClient {
   }
 
   _setAddress(String address) {
-    var prefix = 'unix:path=';
-    if (!address.startsWith(prefix))
-      throw 'D-Bus address not supported: ${address}';
-    var path = address.substring(prefix.length);
+    var prefix = 'unix:';
+    var chunkPrefix = 'path=';
+    if (!address.startsWith(prefix)) throw 'D-Bus address not supported: ${address}';
+
+    var path = address
+        .substring(prefix.length)
+        .split(",")
+        .firstWhere((element) => element.startsWith(chunkPrefix), orElse: () => null)
+        ?.substring(chunkPrefix.length);
+    if (path == null) throw 'D-Bus address not supported: ${address}';
+
     _socket = UnixDomainSocket.create(path);
     var dbusMessages = ReceivePort();
     _messageStream = dbusMessages.asBroadcastStream();


### PR DESCRIPTION
In my machine, `$DBUS_SESSION_BUS_ADDRESS` is equal to `unix:path=/run/user/1000/bus` in vscode, but `unix:path=/run/user/1000/bus,guid=f114316a6facbc740a8cdaf25f0b84aa` in the terminal emulator!

I fixed the code to parse it correctly.
It doesn't handle paths that contain commas, but i'm not sure that's even possible