### PR TITLE
Rename DBusObjectProxy to DBusRemoteObject.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ import 'package:dbus/dbus.dart';
 
 var client = DBusClient.system();
 await client.connect();
-var proxy = DBusObjectProxy(client, 'org.freedesktop.hostname1', DBusObjectPath('/org/freedesktop/hostname1'));
-var result = await proxy.getProperty('org.freedesktop.hostname1', 'Hostname');
+var object = DBusRemoteObject(client, 'org.freedesktop.hostname1', DBusObjectPath('/org/freedesktop/hostname1'));
+var result = await object.getProperty('org.freedesktop.hostname1', 'Hostname');
 var hostname = (result as DBusString).value;
 print('hostname: ${hostname}');
 await client.disconnect();

--- a/example/example.dart
+++ b/example/example.dart
@@ -3,7 +3,7 @@ import 'package:dbus/dbus.dart';
 void main() async {
   var client = DBusClient.session();
   await client.connect();
-  var proxy = DBusObjectProxy(client, 'org.freedesktop.Notifications',
+  var object = DBusRemoteObject(client, 'org.freedesktop.Notifications',
       DBusObjectPath('/org/freedesktop/Notifications'));
   var values = [
     DBusString(''), // App name
@@ -15,8 +15,8 @@ void main() async {
     DBusDict(DBusSignature('s'), DBusSignature('v')), // Hints
     DBusInt32(-1), // Expire timeout
   ];
-  var result =
-      await proxy.callMethod('org.freedesktop.Notifications', 'Notify', values);
+  var result = await object.callMethod(
+      'org.freedesktop.Notifications', 'Notify', values);
   var id = (result.returnValues[0] as DBusUint32).value;
   print('notify ${id}');
   await client.disconnect();

--- a/example/hostname.dart
+++ b/example/hostname.dart
@@ -3,9 +3,10 @@ import 'package:dbus/dbus.dart';
 void main() async {
   var client = DBusClient.system();
   await client.connect();
-  var proxy = DBusObjectProxy(client, 'org.freedesktop.hostname1',
+  var object = DBusRemoteObject(client, 'org.freedesktop.hostname1',
       DBusObjectPath('/org/freedesktop/hostname1'));
-  var result = await proxy.getProperty('org.freedesktop.hostname1', 'Hostname');
+  var result =
+      await object.getProperty('org.freedesktop.hostname1', 'Hostname');
   var hostname = (result as DBusString).value;
   print('hostname: ${hostname}');
   await client.disconnect();

--- a/lib/dbus.dart
+++ b/lib/dbus.dart
@@ -2,5 +2,5 @@ export 'src/dbus_client.dart';
 export 'src/dbus_introspect.dart';
 export 'src/dbus_method_response.dart';
 export 'src/dbus_object.dart';
-export 'src/dbus_object_proxy.dart';
+export 'src/dbus_remote_object.dart';
 export 'src/dbus_value.dart';

--- a/lib/src/dbus_introspect.dart
+++ b/lib/src/dbus_introspect.dart
@@ -287,7 +287,7 @@ class DBusIntrospectAnnotation {
 
 /// Parse D-Bus introspection data.
 ///
-/// Data can received from [DBusObjectProxy.introspect] or from an interface definition document.
+/// Data can received from [DBusRemoteObject.introspect] or from an interface definition document.
 List<DBusIntrospectNode> parseDBusIntrospectXml(String xml) {
   var document = XmlDocument.parse(xml);
   return document

--- a/lib/src/dbus_remote_object.dart
+++ b/lib/src/dbus_remote_object.dart
@@ -3,13 +3,13 @@ import 'dbus_method_response.dart';
 import 'dbus_value.dart';
 
 /// An object to simplify access to a D-Bus object.
-class DBusObjectProxy {
+class DBusRemoteObject {
   final DBusClient client;
   final String destination;
   final DBusObjectPath path;
 
-  /// Creates a new DBus object proxy to access the object at [destination], [path].
-  DBusObjectProxy(this.client, this.destination, this.path);
+  /// Creates an object that access accesses a remote D-Bus object at [destination], [path].
+  DBusRemoteObject(this.client, this.destination, this.path);
 
   /// Gets the introspection data for this object.
   ///


### PR DESCRIPTION
This matches the terminology in the D-Bus specification. (Proxy came from gdbus).