### PR TITLE
Replace getters and settings in DBusRemote object and use methods ins…

### DIFF
--- a/bin/dart-dbus.dart
+++ b/bin/dart-dbus.dart
@@ -522,7 +522,7 @@ List<String> generateRemotePropertyMethods(
     var convertedValue = type.dbusToNative('value');
     var source = '';
     source += '  /// Gets ${interface.name}.${property.name}\n';
-    source += '  Future<${type.nativeType}> get ${property.name} async {\n';
+    source += '  Future<${type.nativeType}> get${property.name}() async {\n';
     source +=
         "    var value = await getProperty('${interface.name}', '${property.name}');\n";
     source += '    return ${convertedValue};\n';
@@ -535,9 +535,10 @@ List<String> generateRemotePropertyMethods(
     var convertedValue = type.nativeToDBus('value');
     var source = '';
     source += '  /// Sets ${interface.name}.${property.name}\n';
-    source += '  set ${property.name} (${type.nativeType} value) {\n';
     source +=
-        "    setProperty('${interface.name}', '${property.name}', ${convertedValue});\n";
+        '  Future set${property.name} (${type.nativeType} value) async {\n';
+    source +=
+        "    await setProperty('${interface.name}', '${property.name}', ${convertedValue});\n";
     source += '  }\n';
     methods.add(source);
   }
@@ -590,7 +591,8 @@ String generateRemoteMethodCall(
 
   var source = '';
   source += '  /// Invokes ${interface.name}.${method.name}()\n';
-  source += '  ${returnType} ${method.name}(${argsList.join(', ')}) async {\n';
+  source +=
+      '  ${returnType} call${method.name}(${argsList.join(', ')}) async {\n';
   if (returnTypes.isEmpty) {
     source += '    ${methodCall}\n';
   } else if (returnTypes.length == 1) {

--- a/lib/src/dbus_remote_object.dart
+++ b/lib/src/dbus_remote_object.dart
@@ -78,7 +78,7 @@ class DBusRemoteObject {
   }
 
   /// Sets a property on this object.
-  void setProperty(String interface, String name, DBusValue value) async {
+  Future setProperty(String interface, String name, DBusValue value) async {
     var result = await client.callMethod(
         destination: destination,
         path: path,


### PR DESCRIPTION
…tead.

Getters and setters need to be symmetrical and this is difficult and/or impossible with async behaviour.
It also can be confusing and make them not look async.
Also use 'call' as a prefix for method calls. The combination of the get/set/call prefixes is more consistent and avoids property/method name collisions.

I would recommend that developers using the generated code modify it to use properties if their API requires it, using org.freedesktop.DBus.ObjectManager or similar.