### PR TITLE
Migration to null safety using dart migrate tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0-nullsafety.0
+
+* Migrated to null safety
+
 ## 0.0.0-dev
 
 * Initial prerelease

--- a/example/example.dart
+++ b/example/example.dart
@@ -16,7 +16,7 @@ void main() async {
   ];
   var result = await object.callMethod(
       'org.freedesktop.Notifications', 'Notify', values);
-  var id = result.returnValues[0];
+  var id = result.returnValues![0];
   print('notify ${id.toNative()}');
   await client.close();
 }

--- a/example/hostname.dart
+++ b/example/hostname.dart
@@ -5,7 +5,7 @@ void main() async {
   var object = DBusRemoteObject(client, 'org.freedesktop.hostname1',
       DBusObjectPath('/org/freedesktop/hostname1'));
   var hostname =
-      await (object.getProperty('org.freedesktop.hostname1', 'Hostname') as Future<DBusValue>);
-  print('hostname: ${hostname.toNative()}');
+      await (object.getProperty('org.freedesktop.hostname1', 'Hostname'));
+  print('hostname: ${hostname!.toNative()}');
   await client.close();
 }

--- a/example/hostname.dart
+++ b/example/hostname.dart
@@ -5,7 +5,7 @@ void main() async {
   var object = DBusRemoteObject(client, 'org.freedesktop.hostname1',
       DBusObjectPath('/org/freedesktop/hostname1'));
   var hostname =
-      await object.getProperty('org.freedesktop.hostname1', 'Hostname');
+      await (object.getProperty('org.freedesktop.hostname1', 'Hostname') as Future<DBusValue>);
   print('hostname: ${hostname.toNative()}');
   await client.close();
 }

--- a/example/object_manager.dart
+++ b/example/object_manager.dart
@@ -14,7 +14,7 @@ void main() async {
         print('${signal.changedPath.value} removed interfaces ${interface}');
       }
     } else if (signal is DBusPropertiesChangedSignal) {
-      print('${signal.path.value}');
+      print('${signal.path!.value}');
       printInterfacesAndProperties(
           {signal.propertiesInterface: signal.changedProperties});
     }
@@ -28,11 +28,11 @@ void main() async {
 }
 
 void printInterfacesAndProperties(
-    Map<String, Map<String, DBusValue>> interfacesAndProperties) {
+    Map<String?, Map<String?, DBusValue?>> interfacesAndProperties) {
   interfacesAndProperties.forEach((interface, properties) {
     print('  ${interface}');
     properties.forEach((name, value) {
-      print('    ${name}: ${value.toNative()}');
+      print('    ${name}: ${value!.toNative()}');
     });
   });
 }

--- a/example/properties.dart
+++ b/example/properties.dart
@@ -8,7 +8,7 @@ void main() async {
   var properties =
       await object.getAllProperties('org.freedesktop.NetworkManager');
   properties.forEach((name, value) {
-    print('${name}: ${value.toNative()}');
+    print('${name}: ${value!.toNative()}');
   });
 
   print('');
@@ -16,15 +16,15 @@ void main() async {
   var devicePaths = (properties['Devices'] as DBusArray).children;
   for (var path in devicePaths) {
     var device =
-        DBusRemoteObject(client, 'org.freedesktop.NetworkManager', path);
-    var address = await device.getProperty(
-        'org.freedesktop.NetworkManager.Device', 'HwAddress');
+        DBusRemoteObject(client, 'org.freedesktop.NetworkManager', path as DBusObjectPath);
+    var address = await (device.getProperty(
+        'org.freedesktop.NetworkManager.Device', 'HwAddress') as Future<DBusValue>);
     print('${address.toNative()}');
   }
 
   await object.subscribePropertiesChanged().listen((signal) {
     signal.changedProperties.forEach((name, value) {
-      print('${name}: ${value.toNative()}');
+      print('${name}: ${value!.toNative()}');
     });
   });
 }

--- a/example/properties.dart
+++ b/example/properties.dart
@@ -18,8 +18,8 @@ void main() async {
     var device =
         DBusRemoteObject(client, 'org.freedesktop.NetworkManager', path as DBusObjectPath);
     var address = await (device.getProperty(
-        'org.freedesktop.NetworkManager.Device', 'HwAddress') as Future<DBusValue>);
-    print('${address.toNative()}');
+        'org.freedesktop.NetworkManager.Device', 'HwAddress'));
+    print('${address!.toNative()}');
   }
 
   await object.subscribePropertiesChanged().listen((signal) {

--- a/example/register_object.dart
+++ b/example/register_object.dart
@@ -23,8 +23,8 @@ class TestObject extends DBusObject {
   }
 
   @override
-  Future<DBusMethodResponse> handleMethodCall(String sender, String interface,
-      String member, List<DBusValue> values) async {
+  Future<DBusMethodResponse> handleMethodCall(String? sender, String? interface,
+      String? member, List<DBusValue>? values) async {
     if (interface != 'com.canonical.DBusDart') {
       return DBusMethodErrorResponse.unknownInterface();
     }
@@ -39,7 +39,7 @@ class TestObject extends DBusObject {
 
   @override
   Future<DBusMethodResponse> getProperty(
-      String interface, String member) async {
+      String? interface, String? member) async {
     if (interface != 'com.canonical.DBusDart') {
       return DBusMethodErrorResponse.unknownInterface();
     }
@@ -53,7 +53,7 @@ class TestObject extends DBusObject {
 
   @override
   Future<DBusMethodResponse> setProperty(
-      String interface, String member, DBusValue value) async {
+      String? interface, String? member, DBusValue? value) async {
     if (interface != 'com.canonical.DBusDart') {
       return DBusMethodErrorResponse.unknownInterface();
     }
@@ -66,7 +66,7 @@ class TestObject extends DBusObject {
   }
 
   @override
-  Future<DBusMethodResponse> getAllProperties(String interface) async {
+  Future<DBusMethodResponse> getAllProperties(String? interface) async {
     if (interface != 'com.canonical.DBusDart') {
       return DBusMethodErrorResponse.unknownInterface();
     }

--- a/example/signals.dart
+++ b/example/signals.dart
@@ -22,7 +22,7 @@ class TestObject extends DBusObject {
 void main(List<String> args) async {
   var client = DBusClient.session();
 
-  String mode;
+  String? mode;
   if (args.isNotEmpty) {
     mode = args[0];
   }
@@ -34,7 +34,7 @@ void main(List<String> args) async {
     );
     var signals = object.subscribeSignal('com.canonical.DBusDart', 'Ping');
     await for (var signal in signals) {
-      var count = (signal.values[0] as DBusUint64).value;
+      var count = (signal.values![0] as DBusUint64).value;
       print('Ping ${count}!');
     }
   } else if (mode == 'server') {

--- a/lib/src/dbus_address.dart
+++ b/lib/src/dbus_address.dart
@@ -14,10 +14,10 @@ class DBusAddressProperty {
 /// An address of a D-Bus server.
 class DBusAddress {
   /// The method of transport, e.g. 'unix', 'tcp'.
-  String transport;
+  String? transport;
 
   /// Transport properties, e.g. 'path': '/run/user/1000/bus'.
-  List<DBusAddressProperty> properties;
+  late List<DBusAddressProperty> properties;
 
   /// Creates a new address from the given [address] string, e.g. 'unix:path=/run/user/1000/bus'.
   DBusAddress(String address) {
@@ -57,7 +57,7 @@ class DBusAddress {
   }
 
   /// Decode an escaped value, e.g. 'Hello%20World' -> 'Hello World'.
-  String _decodeValue(String encodedValue) {
+  String? _decodeValue(String encodedValue) {
     var escapedValue = utf8.encode(encodedValue);
     var binaryValue = <int>[];
     for (var i = 0; i < escapedValue.length; i++) {

--- a/lib/src/dbus_buffer.dart
+++ b/lib/src/dbus_buffer.dart
@@ -47,9 +47,9 @@ class DBusBuffer {
       return SIGNATURE_ALIGNMENT;
     } else if (signature.value == 'v') {
       return VARIANT_ALIGNMENT;
-    } else if (signature.value.startsWith('(')) {
+    } else if (signature.value!.startsWith('(')) {
       return STRUCT_ALIGNMENT;
-    } else if (signature.value.startsWith('a')) {
+    } else if (signature.value!.startsWith('a')) {
       return ARRAY_ALIGNMENT;
     } else {
       return 1;

--- a/lib/src/dbus_dart_type.dart
+++ b/lib/src/dbus_dart_type.dart
@@ -27,7 +27,7 @@ DBusDartType getDartType(DBusSignature signature) {
     return DBusObjectPathType();
   } else if (value == 'v') {
     return DBusVariantType();
-  } else if (value.startsWith('a{') && value.endsWith('}')) {
+  } else if (value!.startsWith('a{') && value.endsWith('}')) {
     var signatures =
         DBusSignature(value.substring(2, value.length - 1)).split();
     if (signatures.length != 2) {
@@ -35,7 +35,7 @@ DBusDartType getDartType(DBusSignature signature) {
     }
     return DBusDictType(signatures[0], signatures[1]);
   } else if (value.startsWith('a')) {
-    var childSignature = DBusSignature(signature.value.substring(1));
+    var childSignature = DBusSignature(signature.value!.substring(1));
     return DBusArrayType(childSignature);
   } else {
     return DBusComplexType();
@@ -45,10 +45,10 @@ DBusDartType getDartType(DBusSignature signature) {
 /// Class that generates Dart code for a D-Bus data type.
 abstract class DBusDartType {
   // Native Dart type for the API user to interact with, e.g. 'int', 'String'.
-  String nativeType;
+  String? nativeType;
 
   // Dart type to pass to dbus.dart, e.g. 'DBusUint32', 'DBusString'.
-  String dbusType;
+  String? dbusType;
 
   // Converts a native Dart variable to a D-Bus data type. e.g. 'foo' -> 'DBusInteger(foo)'.
   String nativeToDBus(String name);

--- a/lib/src/dbus_introspect.dart
+++ b/lib/src/dbus_introspect.dart
@@ -10,7 +10,7 @@ enum DBusArgumentDirection { in_, out }
 /// Introspection information about a D-Bus node.
 class DBusIntrospectNode {
   /// D-Bus object this node represents, either absolute or relative (optional).
-  final String name;
+  final String? name;
 
   /// Interfaces this node uses.
   final List<DBusIntrospectInterface> interfaces;
@@ -37,7 +37,7 @@ class DBusIntrospectNode {
   XmlNode toXml() {
     var attributes = <XmlAttribute>[];
     if (name != null) {
-      attributes.add(XmlAttribute(XmlName('name'), name));
+      attributes.add(XmlAttribute(XmlName('name'), name!));
     }
     var children_ = <XmlNode>[];
     children_.addAll(interfaces.map((i) => i.toXml()));
@@ -54,7 +54,7 @@ class DBusIntrospectNode {
 /// Introspection information about a D-Bus interface.
 class DBusIntrospectInterface {
   /// Name of the interface, e.g. 'org.freedesktop.DBus'.
-  final String name;
+  final String? name;
 
   /// Methods on this interface.
   final List<DBusIntrospectMethod> methods;
@@ -106,7 +106,7 @@ class DBusIntrospectInterface {
     children.addAll(properties.map((p) => p.toXml()));
     children.addAll(annotations.map((a) => a.toXml()));
     return XmlElement(
-        XmlName('interface'), [XmlAttribute(XmlName('name'), name)], children);
+        XmlName('interface'), [XmlAttribute(XmlName('name'), name!)], children);
   }
 
   @override
@@ -118,7 +118,7 @@ class DBusIntrospectInterface {
 /// Introspection information about a D-Bus method.
 class DBusIntrospectMethod {
   /// Name of this method, e.g. 'RequestName'.
-  final String name;
+  final String? name;
 
   /// Arguments to pass to method.
   final List<DBusIntrospectArgument> args;
@@ -147,7 +147,7 @@ class DBusIntrospectMethod {
     children.addAll(args.map((a) => a.toXml()));
     children.addAll(annotations.map((a) => a.toXml()));
     return XmlElement(
-        XmlName('method'), [XmlAttribute(XmlName('name'), name)], children);
+        XmlName('method'), [XmlAttribute(XmlName('name'), name!)], children);
   }
 
   @override
@@ -159,7 +159,7 @@ class DBusIntrospectMethod {
 /// Introspection information about a D-Bus signal.
 class DBusIntrospectSignal {
   /// Name of this signal, e.g. 'NameLost'.
-  final String name;
+  final String? name;
 
   /// Arguments sent with signal.
   final List<DBusIntrospectArgument> args;
@@ -188,7 +188,7 @@ class DBusIntrospectSignal {
     children.addAll(args.map((a) => a.toXml()));
     children.addAll(annotations.map((a) => a.toXml()));
     return XmlElement(
-        XmlName('signal'), [XmlAttribute(XmlName('name'), name)], children);
+        XmlName('signal'), [XmlAttribute(XmlName('name'), name!)], children);
   }
 
   @override
@@ -200,7 +200,7 @@ class DBusIntrospectSignal {
 /// Introspection information about a D-Bus property.
 class DBusIntrospectProperty {
   /// Name of this property, e.g. 'Features'.
-  final String name;
+  final String? name;
 
   /// Type of this property.
   final DBusSignature type;
@@ -236,9 +236,9 @@ class DBusIntrospectProperty {
   XmlNode toXml() {
     var attributes = <XmlAttribute>[];
     if (name != null) {
-      attributes.add(XmlAttribute(XmlName('name'), name));
+      attributes.add(XmlAttribute(XmlName('name'), name!));
     }
-    attributes.add(XmlAttribute(XmlName('type'), type.value));
+    attributes.add(XmlAttribute(XmlName('type'), type.value!));
     if (access == DBusPropertyAccess.readwrite) {
       attributes.add(XmlAttribute(XmlName('access'), 'readwrite'));
     } else if (access == DBusPropertyAccess.read) {
@@ -259,13 +259,13 @@ class DBusIntrospectProperty {
 /// Introspection information about a D-Bus argument.
 class DBusIntrospectArgument {
   /// Name of this argument, e.g. 'name' (optional).
-  final String name;
+  final String? name;
 
   /// Type of this argument.
   final DBusSignature type;
 
   /// Direction this argument is passed.
-  final DBusArgumentDirection direction;
+  final DBusArgumentDirection? direction;
 
   /// Annotations for this argument.
   final List<DBusIntrospectAnnotation> annotations;
@@ -277,7 +277,7 @@ class DBusIntrospectArgument {
     var name = node.getAttribute('name');
     var type = DBusSignature(node.getAttribute('type'));
     var directionText = node.getAttribute('direction');
-    DBusArgumentDirection direction;
+    DBusArgumentDirection? direction;
     if (directionText == 'in') {
       direction = DBusArgumentDirection.in_;
     } else if (directionText == 'out') {
@@ -294,9 +294,9 @@ class DBusIntrospectArgument {
   XmlNode toXml() {
     var attributes = <XmlAttribute>[];
     if (name != null) {
-      attributes.add(XmlAttribute(XmlName('name'), name));
+      attributes.add(XmlAttribute(XmlName('name'), name!));
     }
-    attributes.add(XmlAttribute(XmlName('type'), type.value));
+    attributes.add(XmlAttribute(XmlName('type'), type.value!));
     if (direction == DBusArgumentDirection.in_) {
       attributes.add(XmlAttribute(XmlName('direction'), 'in'));
     } else if (direction == DBusArgumentDirection.out) {
@@ -315,10 +315,10 @@ class DBusIntrospectArgument {
 /// Annotation that applies to a D-Bus interface, method, signal, property or argument.
 class DBusIntrospectAnnotation {
   /// Name of the annotation, e.g. 'org.freedesktop.DBus.Deprecated'.
-  final String name;
+  final String? name;
 
   /// Value of the annotation, e.g. 'true'.
-  final String value;
+  final String? value;
 
   DBusIntrospectAnnotation(this.name, this.value);
 
@@ -330,8 +330,8 @@ class DBusIntrospectAnnotation {
 
   XmlNode toXml() {
     return XmlElement(XmlName('method'), [
-      XmlAttribute(XmlName('name'), name),
-      XmlAttribute(XmlName('value'), value)
+      XmlAttribute(XmlName('name'), name!),
+      XmlAttribute(XmlName('value'), value!)
     ]);
   }
 }

--- a/lib/src/dbus_introspectable.dart
+++ b/lib/src/dbus_introspectable.dart
@@ -19,19 +19,19 @@ DBusIntrospectInterface introspectIntrospectable() {
 
 /// Handles method calls on the org.freedesktop.DBus.Introspectable interface.
 DBusMethodResponse handleIntrospectableMethodCall(DBusObjectTree objectTree,
-    DBusObjectPath path, String member, List<DBusValue> values) {
+    DBusObjectPath? path, String? member, List<DBusValue>? values) {
   if (member == 'Introspect') {
-    if (values.isNotEmpty) {
+    if (values!.isNotEmpty) {
       return DBusMethodErrorResponse.invalidArgs();
     }
 
-    var node = objectTree.lookup(path);
+    var node = objectTree.lookup(path!)!;
     var interfaces = <DBusIntrospectInterface>[];
     if (node != null && node.object != null) {
       interfaces.add(introspectIntrospectable());
       interfaces.add(introspectPeer());
       interfaces.add(introspectProperties());
-      interfaces.addAll(node.object.introspect());
+      interfaces.addAll(node.object!.introspect());
     }
     var children =
         node.children.keys.map((name) => DBusIntrospectNode(name)).toList();

--- a/lib/src/dbus_message.dart
+++ b/lib/src/dbus_message.dart
@@ -48,31 +48,31 @@ class DBusMessage {
   final int flags;
 
   /// Unique serial number for this message.
-  final int serial;
+  final int? serial;
 
   /// Object path this message refers to or null. e.g. '/org/freedesktop/DBus'.
-  final DBusObjectPath path;
+  final DBusObjectPath? path;
 
   /// Interface this message refers to or null. e.g. 'org.freedesktop.DBus.Properties'.
-  final String interface;
+  final String? interface;
 
   /// Member this message refers to or null. e.g. 'Get'.
-  final String member;
+  final String? member;
 
   /// Error name as returned in messages of type MessageType.Error or null. e.g. 'org.freedesktop.DBus.Error.UnknownObject'.
-  final String errorName;
+  final String? errorName;
 
   /// Serial number this message is replying to or null.
-  final int replySerial;
+  final int? replySerial;
 
   /// Destination this message is being sent to or null. e.g. 'org.freedesktop.DBus'.
-  final String destination;
+  final String? destination;
 
   /// Sender of this message is being sent to or null. e.g. 'com.exaple.Test'.
-  final String sender;
+  final String? sender;
 
   /// Values being sent with this message.
-  final List<DBusValue> values;
+  final List<DBusValue>? values;
 
   /// Creates a new D-Bus message.
   DBusMessage(
@@ -140,9 +140,9 @@ class DBusMessage {
     if (sender != null) {
       text += ", sender='${sender}'";
     }
-    if (values.isNotEmpty) {
+    if (values!.isNotEmpty) {
       var valueText = <String>[];
-      for (var value in values) {
+      for (var value in values!) {
         valueText.add(value.toString());
       }
       text += ", values=[${valueText.join(', ')}]";

--- a/lib/src/dbus_method_response.dart
+++ b/lib/src/dbus_method_response.dart
@@ -3,28 +3,28 @@ import 'dbus_value.dart';
 /// A response to a method call.
 abstract class DBusMethodResponse {
   /// Gets the value returned from this method or throws an exception if an error received.
-  List<DBusValue> get returnValues;
+  List<DBusValue>? get returnValues;
 }
 
 /// A success response to a method call.
 class DBusMethodSuccessResponse extends DBusMethodResponse {
   /// Values returned from the method.
-  List<DBusValue> values;
+  List<DBusValue>? values;
 
   /// Creates a new success response to a method call returning [values].
   DBusMethodSuccessResponse([this.values = const []]);
 
   @override
-  List<DBusValue> get returnValues => values;
+  List<DBusValue>? get returnValues => values;
 }
 
 /// An error response to a method call.
 class DBusMethodErrorResponse extends DBusMethodResponse {
   /// The name of the error that occurred.
-  String errorName;
+  String? errorName;
 
   /// Additional values passed with the error.
-  List<DBusValue> values;
+  List<DBusValue>? values;
 
   /// Creates a new error response to a method call with the error [errorName] and optional [values].
   DBusMethodErrorResponse(this.errorName, [this.values = const []]);

--- a/lib/src/dbus_object.dart
+++ b/lib/src/dbus_object.dart
@@ -6,7 +6,7 @@ import 'dbus_value.dart';
 /// An object that is exported on the bus.
 class DBusObject {
   /// The client this object is being exported by.
-  DBusClient client;
+  DBusClient? client;
 
   /// The path this object is registered on.
   DBusObjectPath get path {
@@ -19,25 +19,25 @@ class DBusObject {
   }
 
   /// Called when a method call is received on this object.
-  Future<DBusMethodResponse> handleMethodCall(String sender, String interface,
-      String member, List<DBusValue> values) async {
+  Future<DBusMethodResponse> handleMethodCall(String? sender, String? interface,
+      String? member, List<DBusValue>? values) async {
     return DBusMethodErrorResponse.unknownInterface();
   }
 
   /// Called when a property is requested on this object. On success, return [DBusGetPropertyResponse].
   Future<DBusMethodResponse> getProperty(
-      String interface, String member) async {
+      String? interface, String? member) async {
     return DBusMethodErrorResponse.unknownProperty();
   }
 
   /// Called when a property is set on this object.
   Future<DBusMethodResponse> setProperty(
-      String interface, String member, DBusValue value) async {
+      String? interface, String? member, DBusValue? value) async {
     return DBusMethodErrorResponse.unknownProperty();
   }
 
   /// Called when all properties are requested on this object. On success, return [DBusGetAllPropertiesResponse].
-  Future<DBusMethodResponse> getAllProperties(String interface) async {
+  Future<DBusMethodResponse> getAllProperties(String? interface) async {
     return DBusMethodSuccessResponse(
         [DBusDict(DBusSignature('s'), DBusSignature('v'), {})]);
   }
@@ -45,7 +45,7 @@ class DBusObject {
   /// Emits a signal on this object.
   void emitSignal(String interface, String member,
       [List<DBusValue> values = const []]) {
-    client.emitSignal(
+    client!.emitSignal(
         path: path, interface: interface, member: member, values: values);
   }
 }

--- a/lib/src/dbus_object_tree.dart
+++ b/lib/src/dbus_object_tree.dart
@@ -20,7 +20,7 @@ class DBusObjectTree {
   }
 
   /// Find the node for the given [path], or return null if not in the tree.
-  DBusObjectTreeNode lookup(DBusObjectPath path) {
+  DBusObjectTreeNode? lookup(DBusObjectPath path) {
     var node = root;
     for (var element in path.split()) {
       var child = node.children[element];
@@ -34,7 +34,7 @@ class DBusObjectTree {
   }
 
   /// Find the object for the given [path], or return null if not in the tree.
-  DBusObject lookupObject(DBusObjectPath path) {
+  DBusObject? lookupObject(DBusObjectPath path) {
     var node = lookup(path);
     if (node == null) {
       return null;
@@ -49,7 +49,7 @@ class DBusObjectTreeNode {
   String name;
 
   /// Object registered on this node.
-  DBusObject object;
+  DBusObject? object;
 
   /// Child nodes
   final children = <String, DBusObjectTreeNode>{};

--- a/lib/src/dbus_peer.dart
+++ b/lib/src/dbus_peer.dart
@@ -18,15 +18,15 @@ DBusIntrospectInterface introspectPeer() {
 
 /// Handles method calls on the org.freedesktop.DBus.Peer interface.
 Future<DBusMethodResponse> handlePeerMethodCall(
-    String member, List<DBusValue> values) async {
+    String? member, List<DBusValue>? values) async {
   if (member == 'GetMachineId') {
-    if (values.isNotEmpty) {
+    if (values!.isNotEmpty) {
       return DBusMethodErrorResponse.invalidArgs();
     }
     final machineId = await _getMachineId();
     return DBusMethodSuccessResponse([DBusString(machineId)]);
   } else if (member == 'Ping') {
-    if (values.isNotEmpty) {
+    if (values!.isNotEmpty) {
       return DBusMethodErrorResponse.invalidArgs();
     }
     return DBusMethodSuccessResponse();

--- a/lib/src/dbus_properties.dart
+++ b/lib/src/dbus_properties.dart
@@ -35,26 +35,26 @@ DBusIntrospectInterface introspectProperties() {
 
 /// Handles method calls on the org.freedesktop.DBus.Properties interface.
 Future<DBusMethodResponse> handlePropertiesMethodCall(DBusObjectTree objectTree,
-    DBusObjectPath path, String member, List<DBusValue> values) async {
+    DBusObjectPath? path, String? member, List<DBusValue>? values) async {
   if (member == 'Get') {
-    var node = objectTree.lookup(path);
+    var node = objectTree.lookup(path!);
     if (node == null || node.object == null) {
       return DBusMethodErrorResponse.unknownObject();
     }
-    if (values.length != 2 ||
+    if (values!.length != 2 ||
         values[0].signature != DBusSignature('s') ||
         values[1].signature != DBusSignature('s')) {
       return DBusMethodErrorResponse.invalidArgs();
     }
     var interfaceName = (values[0] as DBusString).value;
     var propertyName = (values[1] as DBusString).value;
-    return await node.object.getProperty(interfaceName, propertyName);
+    return await node.object!.getProperty(interfaceName, propertyName);
   } else if (member == 'Set') {
-    var node = objectTree.lookup(path);
+    var node = objectTree.lookup(path!);
     if (node == null || node.object == null) {
       return DBusMethodErrorResponse.unknownObject();
     }
-    if (values.length != 3 ||
+    if (values!.length != 3 ||
         values[0].signature != DBusSignature('s') ||
         values[1].signature != DBusSignature('s') ||
         values[2].signature != DBusSignature('v')) {
@@ -63,17 +63,17 @@ Future<DBusMethodResponse> handlePropertiesMethodCall(DBusObjectTree objectTree,
     var interfaceName = (values[0] as DBusString).value;
     var propertyName = (values[1] as DBusString).value;
     var value = (values[2] as DBusVariant).value;
-    return await node.object.setProperty(interfaceName, propertyName, value);
+    return await node.object!.setProperty(interfaceName, propertyName, value);
   } else if (member == 'GetAll') {
-    var node = objectTree.lookup(path);
+    var node = objectTree.lookup(path!);
     if (node == null || node.object == null) {
       return DBusMethodErrorResponse.unknownObject();
     }
-    if (values.length != 1 || values[0].signature != DBusSignature('s')) {
+    if (values!.length != 1 || values[0].signature != DBusSignature('s')) {
       return DBusMethodErrorResponse.invalidArgs();
     }
     var interfaceName = (values[0] as DBusString).value;
-    return await node.object.getAllProperties(interfaceName);
+    return await node.object!.getAllProperties(interfaceName);
   } else {
     return DBusMethodErrorResponse.unknownMethod();
   }

--- a/lib/src/dbus_remote_object.dart
+++ b/lib/src/dbus_remote_object.dart
@@ -6,15 +6,15 @@ import 'dbus_value.dart';
 /// Signal received when properties are changed.
 class DBusPropertiesChangedSignal extends DBusSignal {
   /// The interface the properties are on.
-  String get propertiesInterface => (values[0] as DBusString).value;
+  String? get propertiesInterface => (values![0] as DBusString).value;
 
   /// Properties that have changed and their new values.
-  Map<String, DBusValue> get changedProperties =>
-      (values[1] as DBusDict).children.map((name, value) =>
+  Map<String?, DBusValue?> get changedProperties =>
+      (values![1] as DBusDict).children.map((name, value) =>
           MapEntry((name as DBusString).value, (value as DBusVariant).value));
 
   /// Properties that have changed but require their values to be requested.
-  List<String> get invalidatedProperties => (values[2] as DBusArray)
+  List<String?> get invalidatedProperties => (values![2] as DBusArray)
       .children
       .map((value) => (value as DBusString).value)
       .toList();
@@ -27,11 +27,11 @@ class DBusPropertiesChangedSignal extends DBusSignal {
 /// Signal received when interfaces are added.
 class DBusObjectManagerInterfacesAddedSignal extends DBusSignal {
   /// Path of the object that has interfaces added to.
-  DBusObjectPath get changedPath => values[0] as DBusObjectPath;
+  DBusObjectPath get changedPath => values![0] as DBusObjectPath;
 
   /// The properties and interfaces that were added.
-  Map<String, Map<String, DBusValue>> get interfacesAndProperties =>
-      _decodeInterfacesAndProperties(values[1]);
+  Map<String?, Map<String?, DBusValue?>> get interfacesAndProperties =>
+      _decodeInterfacesAndProperties(values![1]);
 
   DBusObjectManagerInterfacesAddedSignal(DBusSignal signal)
       : super(signal.sender, signal.path, signal.interface, signal.member,
@@ -41,10 +41,10 @@ class DBusObjectManagerInterfacesAddedSignal extends DBusSignal {
 /// Signal received when interfaces are removed.
 class DBusObjectManagerInterfacesRemovedSignal extends DBusSignal {
   /// Path of the object that has interfaces removed from.
-  DBusObjectPath get changedPath => values[0] as DBusObjectPath;
+  DBusObjectPath get changedPath => values![0] as DBusObjectPath;
 
   /// The interfaces that were removed.
-  List<String> get interfaces => (values[1] as DBusArray)
+  List<String?> get interfaces => (values![1] as DBusArray)
       .children
       .map((value) => (value as DBusString).value)
       .toList();
@@ -70,23 +70,23 @@ class DBusRemoteObject {
         path: path,
         interface: 'org.freedesktop.DBus.Introspectable',
         member: 'Introspect');
-    var values = result.returnValues;
+    var values = result.returnValues!;
     if (values.length != 1 || values[0].signature != DBusSignature('s')) {
       throw 'org.freedesktop.DBus.Introspectable.Introspect returned invalid result: ${values}';
     }
-    var xml = await (values[0] as DBusString).value;
+    var xml = await (values[0] as DBusString).value!;
     return parseDBusIntrospectXml(xml);
   }
 
   /// Gets a property on this object.
-  Future<DBusValue> getProperty(String interface, String name) async {
+  Future<DBusValue?> getProperty(String interface, String name) async {
     var result = await client.callMethod(
         destination: destination,
         path: path,
         interface: 'org.freedesktop.DBus.Properties',
         member: 'Get',
         values: [DBusString(interface), DBusString(name)]);
-    var values = result.returnValues;
+    var values = result.returnValues!;
     if (values.length != 1 || values[0].signature != DBusSignature('v')) {
       throw 'org.freedesktop.DBus.Properties.Get returned invalid result: ${values}';
     }
@@ -94,14 +94,14 @@ class DBusRemoteObject {
   }
 
   /// Gets the values of all the properties on this object.
-  Future<Map<String, DBusValue>> getAllProperties(String interface) async {
+  Future<Map<String?, DBusValue?>> getAllProperties(String interface) async {
     var result = await client.callMethod(
         destination: destination,
         path: path,
         interface: 'org.freedesktop.DBus.Properties',
         member: 'GetAll',
         values: [DBusString(interface)]);
-    var values = result.returnValues;
+    var values = result.returnValues!;
     if (values.length != 1 || values[0].signature != DBusSignature('a{sv}')) {
       throw 'org.freedesktop.DBus.Properties.GetAll returned invalid result: ${values}';
     }
@@ -117,7 +117,7 @@ class DBusRemoteObject {
         interface: 'org.freedesktop.DBus.Properties',
         member: 'Set',
         values: [DBusString(interface), DBusString(name), DBusVariant(value)]);
-    var values = result.returnValues;
+    var values = result.returnValues!;
     if (values.isNotEmpty) {
       throw 'org.freedesktop.DBus.Properties.set returned invalid result: ${values}';
     }
@@ -128,10 +128,10 @@ class DBusRemoteObject {
     var signals =
         subscribeSignal('org.freedesktop.DBus.Properties', 'PropertiesChanged');
     await for (var signal in signals) {
-      if (signal.values.length != 3 ||
-          signal.values[0].signature != DBusSignature('s') ||
-          signal.values[1].signature != DBusSignature('a{sv}') ||
-          signal.values[2].signature != DBusSignature('as')) {
+      if (signal.values!.length != 3 ||
+          signal.values![0].signature != DBusSignature('s') ||
+          signal.values![1].signature != DBusSignature('a{sv}') ||
+          signal.values![2].signature != DBusSignature('as')) {
         continue;
       }
 
@@ -158,20 +158,20 @@ class DBusRemoteObject {
 
   /// Gets all the sub-tree of objects, interfaces and properties of this object.
   /// Requires the remote object to implement the org.freedesktop.DBus.ObjectManager interface.
-  Future<Map<DBusObjectPath, Map<String, Map<String, DBusValue>>>>
+  Future<Map<DBusObjectPath, Map<String?, Map<String?, DBusValue?>>>>
       getManagedObjects() async {
     var result = await client.callMethod(
         destination: destination,
         path: path,
         interface: 'org.freedesktop.DBus.ObjectManager',
         member: 'GetManagedObjects');
-    var values = result.returnValues;
+    var values = result.returnValues!;
     if (values.length != 1 ||
         values[0].signature != DBusSignature('a{oa{sa{sv}}}')) {
       throw 'GetManagedObjects returned invalid result: ${values}';
     }
 
-    Map<DBusObjectPath, Map<String, Map<String, DBusValue>>> decodeObjects(
+    Map<DBusObjectPath, Map<String?, Map<String?, DBusValue?>>> decodeObjects(
         DBusValue objects) {
       return (objects as DBusDict).children.map((key, value) => MapEntry(
           key as DBusObjectPath, _decodeInterfacesAndProperties(value)));
@@ -189,26 +189,26 @@ class DBusRemoteObject {
     await for (var signal in signals) {
       if (signal.interface == 'org.freedesktop.DBus.ObjectManager' &&
           signal.member == 'InterfacesAdded') {
-        if (signal.values.length != 2 ||
-            signal.values[0].signature != DBusSignature('o') ||
-            signal.values[1].signature != DBusSignature('a{sa{sv}}')) {
+        if (signal.values!.length != 2 ||
+            signal.values![0].signature != DBusSignature('o') ||
+            signal.values![1].signature != DBusSignature('a{sa{sv}}')) {
           continue;
         }
         yield DBusObjectManagerInterfacesAddedSignal(signal);
       } else if (signal.interface == 'org.freedesktop.DBus.ObjectManager' &&
           signal.member == 'InterfacesRemoved') {
-        if (signal.values.length != 2 ||
-            signal.values[0].signature != DBusSignature('o') ||
-            signal.values[1].signature != DBusSignature('as')) {
+        if (signal.values!.length != 2 ||
+            signal.values![0].signature != DBusSignature('o') ||
+            signal.values![1].signature != DBusSignature('as')) {
           continue;
         }
         yield DBusObjectManagerInterfacesRemovedSignal(signal);
       } else if (signal.interface == 'org.freedesktop.DBus.Properties' &&
           signal.member == 'PropertiesChanged') {
-        if (signal.values.length != 3 ||
-            signal.values[0].signature != DBusSignature('s') ||
-            signal.values[1].signature != DBusSignature('a{sv}') ||
-            signal.values[2].signature != DBusSignature('as')) {
+        if (signal.values!.length != 3 ||
+            signal.values![0].signature != DBusSignature('s') ||
+            signal.values![1].signature != DBusSignature('a{sv}') ||
+            signal.values![2].signature != DBusSignature('as')) {
           continue;
         }
         yield DBusPropertiesChangedSignal(signal);
@@ -225,14 +225,14 @@ class DBusRemoteObject {
 }
 
 /// Decodes a value with signature 'a{sa{sv}}'.
-Map<String, Map<String, DBusValue>> _decodeInterfacesAndProperties(
+Map<String?, Map<String?, DBusValue?>> _decodeInterfacesAndProperties(
     DBusValue object) {
   return (object as DBusDict).children.map((key, value) =>
       MapEntry((key as DBusString).value, _decodeProperties(value)));
 }
 
 /// Decodes a value with signature 'a{sv}'.
-Map<String, DBusValue> _decodeProperties(DBusValue object) {
+Map<String?, DBusValue?> _decodeProperties(DBusValue object) {
   return (object as DBusDict).children.map((key, value) =>
       MapEntry((key as DBusString).value, (value as DBusVariant).value));
 }

--- a/lib/src/dbus_value.dart
+++ b/lib/src/dbus_value.dart
@@ -163,7 +163,7 @@ class DBusInt32 extends DBusValue {
 /// D-Bus representation of an unsigned 32 bit integer.
 class DBusUint32 extends DBusValue {
   /// An integer in the range [0, 4294967295]
-  final int value;
+  final int? value;
 
   /// Creates a new unsigned 32 bit integer with the given [value].
   const DBusUint32(this.value);
@@ -283,7 +283,7 @@ class DBusDouble extends DBusValue {
 /// D-Bus representation of an Unicode text string.
 class DBusString extends DBusValue {
   /// A Unicode text string.
-  final String value;
+  final String? value;
 
   /// Creates a new Unicode text string with the given [value].
   const DBusString(this.value);
@@ -319,9 +319,9 @@ class DBusObjectPath extends DBusString {
   /// Creates a new D-Bus object path with the given [value].
   ///
   /// An exception is shown if [value] is not a valid object path.
-  DBusObjectPath(String value) : super(value) {
+  DBusObjectPath(String? value) : super(value) {
     if (value != '/') {
-      if (value.contains(RegExp('[^a-zA-Z0-9_/]')) ||
+      if (value!.contains(RegExp('[^a-zA-Z0-9_/]')) ||
           !value.startsWith('/') ||
           value.endsWith('/')) {
         throw 'Invalid object path: ${value}';
@@ -341,13 +341,13 @@ class DBusObjectPath extends DBusString {
     if (value == '/') {
       return [];
     } else {
-      return value.substring(1).split('/');
+      return value!.substring(1).split('/');
     }
   }
 
   /// Returns true if this object path is under [namespace]. e.g. '/org/freedesktop/DBus' is under '/org/freedesktop'.
   bool isInNamespace(DBusObjectPath namespace) {
-    return value == namespace.value || value.startsWith(namespace.value + '/');
+    return value == namespace.value || value!.startsWith(namespace.value! + '/');
   }
 
   @override
@@ -394,7 +394,7 @@ class DBusObjectPath extends DBusString {
 /// * `a{kv}` → [DBusDict] (`k` and `v` represent the key and value signatures).
 class DBusSignature extends DBusValue {
   /// A D-Bus signature string.
-  final String value;
+  final String? value;
 
   /// Create a new D-Bus signature with the given [value].
   const DBusSignature(this.value);
@@ -404,9 +404,9 @@ class DBusSignature extends DBusValue {
     var signatures = <DBusSignature>[];
 
     var start = 0;
-    while (start < value.length) {
+    while (start < value!.length) {
       var end = _findChildEnd(start);
-      signatures.add(DBusSignature(value.substring(start, end)));
+      signatures.add(DBusSignature(value!.substring(start, end)));
       start = end;
     }
 
@@ -416,14 +416,14 @@ class DBusSignature extends DBusValue {
   /// Gets the end of the child signature starting at [offset].
   int _findChildEnd(int offset) {
     /// Dicts and structs have the child type following.
-    if (value[offset] == 'a') {
+    if (value![offset] == 'a') {
       return _findChildEnd(offset + 1);
     }
 
     // Structs and dict entries are multiple characters, everything else is a single character.
-    if (value[offset] == '(') {
+    if (value![offset] == '(') {
       return _findClosing(offset, ')');
-    } else if (value[offset] == '{') {
+    } else if (value![offset] == '{') {
       return _findClosing(offset, '}');
     } else {
       return offset + 1;
@@ -432,13 +432,13 @@ class DBusSignature extends DBusValue {
 
   // Find the closing parenthesis/brace.
   int _findClosing(int start, String closeChar) {
-    var openChar = value[start];
+    var openChar = value![start];
     var count = 0;
     var end = start;
-    while (end < value.length) {
-      if (value[end] == openChar) {
+    while (end < value!.length) {
+      if (value![end] == openChar) {
         count++;
-      } else if (value[end] == closeChar) {
+      } else if (value![end] == closeChar) {
         count--;
         if (count == 0) {
           return end + 1;
@@ -475,7 +475,7 @@ class DBusSignature extends DBusValue {
 /// D-Bus value that contains any D-Bus type.
 class DBusVariant extends DBusValue {
   /// The value contained in this variant.
-  final DBusValue value;
+  final DBusValue? value;
 
   /// Creates a new D-Bus variant containing [value].
   const DBusVariant(this.value);
@@ -487,7 +487,7 @@ class DBusVariant extends DBusValue {
 
   @override
   dynamic toNative() {
-    return value.toNative();
+    return value!.toNative();
   }
 
   @override
@@ -514,7 +514,7 @@ class DBusStruct extends DBusValue {
   DBusSignature get signature {
     var signature = '';
     for (var child in children) {
-      signature += child.signature.value;
+      signature += child.signature.value!;
     }
     return DBusSignature('(' + signature + ')');
   }
@@ -568,7 +568,7 @@ class DBusArray extends DBusValue {
 
   @override
   DBusSignature get signature {
-    return DBusSignature('a' + childSignature.value);
+    return DBusSignature('a' + childSignature.value!);
   }
 
   @override

--- a/lib/src/dbus_write_buffer.dart
+++ b/lib/src/dbus_write_buffer.dart
@@ -13,7 +13,7 @@ class DBusWriteBuffer extends DBusBuffer {
   /// Writes a [DBusMessage] to the buffer.
   void writeMessage(DBusMessage message) {
     var valueBuffer = DBusWriteBuffer();
-    for (var value in message.values) {
+    for (var value in message.values!) {
       valueBuffer.writeValue(value);
     }
 
@@ -50,10 +50,10 @@ class DBusWriteBuffer extends DBusBuffer {
     if (message.sender != null) {
       headers.add(_makeHeader(HeaderCode.Sender, DBusString(message.sender)));
     }
-    if (message.values.isNotEmpty) {
+    if (message.values!.isNotEmpty) {
       var signature = '';
-      for (var value in message.values) {
-        signature += value.signature.value;
+      for (var value in message.values!) {
+        signature += value.signature.value!;
       }
       headers.add(_makeHeader(HeaderCode.Signature, DBusSignature(signature)));
     }
@@ -63,7 +63,7 @@ class DBusWriteBuffer extends DBusBuffer {
   }
 
   /// Makes a new message header.
-  DBusStruct _makeHeader(int code, DBusValue value) {
+  DBusStruct _makeHeader(int code, DBusValue? value) {
     return DBusStruct([DBusByte(code), DBusVariant(value)]);
   }
 
@@ -144,7 +144,7 @@ class DBusWriteBuffer extends DBusBuffer {
       writeInt32(value.value);
     } else if (value is DBusUint32) {
       align(UINT32_ALIGNMENT);
-      writeUint32(value.value);
+      writeUint32(value.value!);
     } else if (value is DBusInt64) {
       align(INT64_ALIGNMENT);
       writeInt64(value.value);
@@ -155,21 +155,21 @@ class DBusWriteBuffer extends DBusBuffer {
       align(DOUBLE_ALIGNMENT);
       writeFloat64(value.value);
     } else if (value is DBusString) {
-      var data = utf8.encode(value.value);
+      var data = utf8.encode(value.value!);
       writeValue(DBusUint32(data.length));
       for (var d in data) {
         writeByte(d);
       }
       writeByte(0); // Terminating nul.
     } else if (value is DBusSignature) {
-      var data = utf8.encode(value.value);
+      var data = utf8.encode(value.value!);
       writeByte(data.length);
       for (var d in data) {
         writeByte(d);
       }
       writeByte(0);
     } else if (value is DBusVariant) {
-      var childValue = value.value;
+      var childValue = value.value!;
       writeValue(childValue.signature);
       writeValue(childValue);
     } else if (value is DBusStruct) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dbus
-version: 0.1.0
+version: 0.2.0-nullsafety.0
 
 description:
   A native Dart implementation of the D-Bus message bus client. This package
@@ -8,11 +8,11 @@ description:
 homepage: https://github.com/canonical/dbus.dart
 
 environment:
-  sdk: '>=2.7.2 <3.0.0'
+  sdk: '>=2.12.0-259.1.beta <3.0.0'
 
 dependencies:
-  args: ^1.6.0
-  xml: ^4.3.0
+  args: ^2.0.0-nullsafety
+  xml: ^5.0.0-nullsafety
 
 dev_dependencies:
   pedantic: ^1.9.0


### PR DESCRIPTION
As reported in https://github.com/canonical/dbus.dart/issues/119 we would like to have a version of dbus with null safety support.

In this PR I have applied the guide from dart.dev to perform a null safety migration, using the `dart migrate` tool and following its steps.

I also had to do some changes regarding the use of `Future<void>` to be compatible with the latest dart changes.

Going to be sincere: I haven't tested this, also I don't see tests that I can run, so I cannot warranty that this is bug free, this will require someone who has knowledge of how the package works to go through it and check it.

Please feel free to perform any changes directly without asking and take the work from there.

Also, I would need to sign the https://ubuntu.com/legal/contributors/agreement but I need to give a "Canonical Project Manager or contact" which I don't have, so let me know who to mention.

Thanks for taking time on this and hopefully you will consider this change.