### PR TITLE
Fix usage for List.firstWhere

### DIFF
--- a/lib/src/dbus_client.dart
+++ b/lib/src/dbus_client.dart
@@ -573,8 +573,8 @@ class DBusClient {
 
   /// Processes a method return or error result from the D-Bus server.
   void _processMethodResponse(DBusMessage message) {
-    var methodCall =
-        _methodCalls.firstWhere((c) => c.serial == message.replySerial);
+    var methodCall = _methodCalls
+        .firstWhere((c) => c.serial == message.replySerial, orElse: () => null);
     if (methodCall == null) {
       return;
     }


### PR DESCRIPTION
It throws an exception if it doesn't match.