### PR TITLE
Fix regression in matching signals using pathNamespace

### DIFF
--- a/lib/src/dbus_client.dart
+++ b/lib/src/dbus_client.dart
@@ -758,7 +758,7 @@ class DBusClient {
         continue;
       }
       if (subscription.pathNamespace != null &&
-          message.path!.isInNamespace(subscription.pathNamespace!)) {
+          !message.path!.isInNamespace(subscription.pathNamespace!)) {
         continue;
       }
 


### PR DESCRIPTION
Introduced in the null-safety changes in f1c6ae2ec2cbc4513bc138f1c6800fefb87d15fa