### PR TITLE
Fix server authentication failing with Unix FD negotiation

### DIFF
--- a/lib/src/dbus_auth_server.dart
+++ b/lib/src/dbus_auth_server.dart
@@ -74,6 +74,7 @@ class DBusAuthServer {
         _reject('Received error');
         break;
       case 'NEGOTIATE_UNIX_FD':
+        _error('Unix fd not supported');
         break;
       default:
         _error("Unknown command '$command'");


### PR DESCRIPTION
Broken in d814ef1c3325e1e078a5f6bd8e7a61086c058c03