### PR TITLE
Change DBusObject.path from a property to a constructor.

### DIFF
--- a/bin/dart-dbus.dart
+++ b/bin/dart-dbus.dart
@@ -133,6 +133,9 @@ String? generateObjectClass(DBusIntrospectNode node, String className) {
   var getMethodNames = <String, String>{};
   var setMethodNames = <String, String>{};
 
+  /// Make a constructor.
+  methods.add(generateConstructor(node, className));
+
   // Generate all the methods for this object.
   for (var interface in node.interfaces) {
     for (var property in interface.properties) {
@@ -156,6 +159,16 @@ String? generateObjectClass(DBusIntrospectNode node, String className) {
   source += 'class $className extends DBusObject {\n';
   source += methods.join('\n');
   source += '}\n';
+
+  return source;
+}
+
+/// Generates a constructor for a DBusObject.
+String generateConstructor(DBusIntrospectNode node, String className) {
+  var source = '';
+  source += '  /// Creates a new object to expose on [path].\n';
+  source +=
+      "  $className({DBusObjectPath path = const DBusObjectPath.unchecked('${node.name ?? '/'}')}) : super(path);\n";
 
   return source;
 }

--- a/example/register_object.dart
+++ b/example/register_object.dart
@@ -6,10 +6,7 @@ import 'package:dbus/dbus.dart';
 class TestObject extends DBusObject {
   var callCount = 0;
 
-  @override
-  DBusObjectPath get path {
-    return DBusObjectPath('/com/canonical/DBusDart');
-  }
+  TestObject() : super(DBusObjectPath('/com/canonical/DBusDart'));
 
   @override
   List<DBusIntrospectInterface> introspect() {

--- a/example/signals.dart
+++ b/example/signals.dart
@@ -3,10 +3,7 @@ import 'dart:async';
 import 'package:dbus/dbus.dart';
 
 class TestObject extends DBusObject {
-  @override
-  DBusObjectPath get path {
-    return DBusObjectPath('/com/canonical/DBusDart');
-  }
+  TestObject() : super(DBusObjectPath('/com/canonical/DBusDart'));
 
   @override
   List<DBusIntrospectInterface> introspect() {

--- a/lib/src/dbus_object.dart
+++ b/lib/src/dbus_object.dart
@@ -6,13 +6,14 @@ import 'dbus_value.dart';
 
 /// An object that is exported on the bus.
 class DBusObject {
+  /// The path this object is registered on.
+  final DBusObjectPath path;
+
   /// The client this object is being exported by.
   DBusClient? client;
 
-  /// The path this object is registered on.
-  DBusObjectPath get path {
-    return DBusObjectPath('/');
-  }
+  /// Creates a new object to export on the bus at [path].
+  DBusObject(this.path);
 
   /// Called to get introspection information about this object.
   List<DBusIntrospectInterface> introspect() {

--- a/test/test.dart
+++ b/test/test.dart
@@ -37,7 +37,8 @@ class MethodCallObject extends DBusObject {
       this.values,
       this.flags = const {},
       this.responseValues = const [],
-      this.errorName});
+      this.errorName})
+      : super(DBusObjectPath('/'));
 
   @override
   Future<DBusMethodResponse> handleMethodCall(DBusMethodCall methodCall) async {
@@ -59,6 +60,8 @@ class MethodCallObject extends DBusObject {
 
 // Test object which has introspection data.
 class IntrospectObject extends DBusObject {
+  IntrospectObject() : super(DBusObjectPath('/'));
+
   @override
   List<DBusIntrospectInterface> introspect() {
     return [
@@ -76,7 +79,8 @@ class PropertiesObject extends DBusObject {
   PropertiesObject(
       {this.readWriteValue = '',
       this.readOnlyValue = '',
-      this.writeOnlyValue = ''});
+      this.writeOnlyValue = ''})
+      : super(DBusObjectPath('/'));
 
   @override
   Future<DBusMethodResponse> getProperty(
@@ -733,7 +737,7 @@ void main() {
     var client2 = DBusClient(address);
 
     // Create a client to emit a signal.
-    var object = DBusObject();
+    var object = DBusObject(DBusObjectPath('/'));
     await client1.registerObject(object);
 
     // Subscribe to the signal from another client.
@@ -763,7 +767,7 @@ void main() {
     var client2 = DBusClient(address);
 
     // Create a client to emit a signal.
-    var object = DBusObject();
+    var object = DBusObject(DBusObjectPath('/'));
     await client1.registerObject(object);
 
     // Subscribe to the signal from another client.
@@ -794,7 +798,7 @@ void main() {
     var client2 = DBusClient(address);
 
     // Create a client to emit a signal.
-    var object = DBusObject();
+    var object = DBusObject(DBusObjectPath('/'));
     await client1.requestName('com.example.Test');
     await client1.registerObject(object);
 


### PR DESCRIPTION
The path can never change so it is safer to ensure this and more efficient to use a final.

Fixes https://github.com/canonical/dbus.dart/issues/190