### PR TITLE
Remove explicit method calls to subscribe to signals.

### DIFF
--- a/example/object_manager.dart
+++ b/example/object_manager.dart
@@ -5,7 +5,7 @@ void main() async {
   var object = DBusRemoteObject(client, 'org.freedesktop.NetworkManager',
       DBusObjectPath('/org/freedesktop'));
 
-  object.subscribeObjectManagerSignals().listen((signal) {
+  object.objectManagerSignals.listen((signal) {
     if (signal is DBusObjectManagerInterfacesAddedSignal) {
       print('${signal.changedPath.value}');
       printInterfacesAndProperties(signal.interfacesAndProperties);

--- a/example/properties.dart
+++ b/example/properties.dart
@@ -24,7 +24,7 @@ void main() async {
     print('${address.toNative()}');
   }
 
-  object.subscribePropertiesChanged().listen((signal) {
+  object.propertiesChanged.listen((signal) {
     signal.changedProperties.forEach((name, value) {
       print('$name: ${value.toNative()}');
     });

--- a/example/signals.dart
+++ b/example/signals.dart
@@ -29,7 +29,8 @@ void main(List<String> args) async {
       'com.canonical.DBusDart',
       DBusObjectPath('/com/canonical/DBusDart'),
     );
-    var signals = object.subscribeSignal('com.canonical.DBusDart', 'Ping');
+    var signals =
+        DBusRemoteObjectSignalStream(object, 'com.canonical.DBusDart', 'Ping');
     await for (var signal in signals) {
       var count = (signal.values[0] as DBusUint64).value;
       print('Ping $count!');

--- a/test/test.dart
+++ b/test/test.dart
@@ -740,7 +740,7 @@ void main() {
 
     // Subscribe to the signal from another client.
     var signals =
-        client2.subscribeSignals(interface: 'com.example.Test', name: 'Ping');
+        DBusSignalStream(client2, interface: 'com.example.Test', name: 'Ping');
     signals.listen(expectAsync1((signal) {
       expect(signal.sender, equals(client1.uniqueName));
       expect(signal.path, equals(DBusObjectPath('/')));
@@ -771,7 +771,8 @@ void main() {
     // Subscribe to the signal from another client.
     var remoteObject =
         DBusRemoteObject(client2, client1.uniqueName, DBusObjectPath('/'));
-    var signals = remoteObject.subscribeSignal('com.example.Test', 'Ping');
+    var signals =
+        DBusRemoteObjectSignalStream(remoteObject, 'com.example.Test', 'Ping');
     signals.listen(expectAsync1((signal) {
       expect(signal.sender, equals(client1.uniqueName));
       expect(signal.path, equals(DBusObjectPath('/')));
@@ -803,7 +804,8 @@ void main() {
     // Subscribe to the signal from another client.
     var remoteObject =
         DBusRemoteObject(client2, 'com.example.Test', DBusObjectPath('/'));
-    var signals = remoteObject.subscribeSignal('com.example.Test', 'Ping');
+    var signals =
+        DBusRemoteObjectSignalStream(remoteObject, 'com.example.Test', 'Ping');
     signals.listen(expectAsync1((signal) {
       expect(signal.sender, equals(client1.uniqueName));
       expect(signal.path, equals(DBusObjectPath('/')));
@@ -1013,8 +1015,7 @@ void main() {
     /// Subscribe to properties changed signals.
     var remoteObject =
         DBusRemoteObject(client2, client1.uniqueName, DBusObjectPath('/'));
-    var signals = remoteObject.subscribePropertiesChanged();
-    signals.listen(expectAsync1((signal) {
+    remoteObject.propertiesChanged.listen(expectAsync1((signal) {
       expect(signal.propertiesInterface, equals('com.example.Test'));
       expect(
           signal.changedProperties,


### PR DESCRIPTION
Since the signal subscription is only done when the stream is listened to, we can create the streams immediately.