### PR TITLE
Support abstract unix domain addresses

### DIFF
--- a/lib/src/dbus_client.dart
+++ b/lib/src/dbus_client.dart
@@ -667,7 +667,12 @@ class DBusClient {
       case 'unix':
         var path = _address.properties['path'];
         if (path == null) {
-          throw "Unable to determine D-Bus unix address path from address '$_address'";
+          path = _address.properties['abstract'];
+          if (path == null) {
+            throw "Unable to determine D-Bus unix address path from address '$_address'";
+          }
+          // Dart expects abstract unix socket paths to be prepended with '@'.
+          path = '@$path';
         }
 
         socketAddress = InternetAddress(path, type: InternetAddressType.unix);

--- a/test/dbus_test.dart
+++ b/test/dbus_test.dart
@@ -546,6 +546,17 @@ void main() {
     await client.close();
   });
 
+  test('ping - abstract', () async {
+    var server = DBusServer();
+    var address =
+        await server.listenAddress(DBusAddress.unix(abstract: 'abstract'));
+    var client = DBusClient(address);
+
+    // Check can ping the server.
+    await client.ping();
+    await client.close();
+  });
+
   test('ping - ipv4 tcp', () async {
     var server = DBusServer();
     var address = await server.listenAddress(


### PR DESCRIPTION
Following 2.14.0-170.0.dev, an issue (https://github.com/dart-lang/sdk/issues/46149) with abstract unix domain socket support in the Dart SDK is addressed. This PR doesn't depend on that version, but this PR will change the failure mode from throwing a string exception to throwing a `SocketException` before that version.