### PR TITLE
Add DBusMaybe type.

### DIFF
--- a/lib/src/dbus_read_buffer.dart
+++ b/lib/src/dbus_read_buffer.dart
@@ -370,7 +370,11 @@ class DBusReadBuffer extends DBusBuffer {
       throw 'Signature missing trailing nul';
     }
 
-    return DBusSignature(utf8.decode(values.toList()));
+    var signatureText = utf8.decode(values.toList());
+    if (signatureText.contains('m')) {
+      throw 'Signature contains reserved maybe type';
+    }
+    return DBusSignature(signatureText);
   }
 
   /// Reads a [DBusVariant] from the buffer or returns null if not enough data.
@@ -482,6 +486,8 @@ class DBusReadBuffer extends DBusBuffer {
       return readDBusSignature();
     } else if (s == 'v') {
       return readDBusVariant(endian);
+    } else if (s == 'm') {
+      throw 'D-Bus reserved maybe type not valid';
     } else if (s.startsWith('a{') && s.endsWith('}')) {
       var childSignature = DBusSignature(s.substring(2, s.length - 1));
       var signatures = childSignature.split();
@@ -495,7 +501,7 @@ class DBusReadBuffer extends DBusBuffer {
       return readDBusStruct(
           DBusSignature(s.substring(1, s.length - 1)).split(), endian);
     } else {
-      throw "Unknown DBus data type '$s'";
+      throw "Unknown D-Bus data type '$s'";
     }
   }
 

--- a/lib/src/dbus_value.dart
+++ b/lib/src/dbus_value.dart
@@ -451,6 +451,7 @@ class DBusObjectPath extends DBusString {
 /// * `o` → [DBusObjectPath]
 /// * `g` → [DBusSignature]
 /// * `v` → [DBusVariant]
+/// * `m` → [DBusMaybe]
 /// * `(xyz...)` → [DBusStruct] (`x`, `y`, `z` represent the child value signatures).
 /// * `av` → [DBusArray] (v represents the array value signature).
 /// * `a{kv}` → [DBusDict] (`k` and `v` represent the key and value signatures).
@@ -534,7 +535,7 @@ class DBusSignature extends DBusValue {
         throw ArgumentError.value(value, 'value', 'Array missing child type');
       }
       return _validate(value, index + 1);
-    } else if ('ybnqiuxtdsogvha'.contains(value[index])) {
+    } else if ('ybnqiuxtdsogvmha'.contains(value[index])) {
       return index;
     } else {
       throw ArgumentError.value(
@@ -626,6 +627,48 @@ class DBusVariant extends DBusValue {
   @override
   String toString() {
     return 'DBusVariant(${value.toString()})';
+  }
+}
+
+/// D-Bus value that contains a D-Bus type or null.
+/// This type is reserved for future use, and is not currently able to be sent or received using D-Bus.
+class DBusMaybe extends DBusValue {
+  /// Signature of the value this maybe contains.
+  final DBusSignature valueSignature;
+
+  /// The value contained in this maybe.
+  final DBusValue? value;
+
+  /// Creates a new D-Bus maybe containing [value].
+  DBusMaybe(this.valueSignature, this.value) {
+    if (value != null && value!.signature.value != valueSignature.value) {
+      throw ArgumentError.value(
+          value, 'value', "Value doesn't match signature $valueSignature");
+    }
+  }
+
+  @override
+  DBusSignature get signature {
+    return DBusSignature('m' + valueSignature.value);
+  }
+
+  @override
+  dynamic toNative() {
+    return value?.toNative();
+  }
+
+  @override
+  bool operator ==(other) =>
+      other is DBusMaybe &&
+      other.valueSignature == valueSignature &&
+      other.value == value;
+
+  @override
+  int get hashCode => valueSignature.hashCode | value.hashCode;
+
+  @override
+  String toString() {
+    return 'DBusMaybe($valueSignature, ${value?.toString()})';
   }
 }
 

--- a/lib/src/dbus_write_buffer.dart
+++ b/lib/src/dbus_write_buffer.dart
@@ -172,6 +172,10 @@ class DBusWriteBuffer extends DBusBuffer {
       }
       writeByte(0); // Terminating nul.
     } else if (value is DBusSignature) {
+      if (value.value.contains('m')) {
+        throw UnsupportedError(
+            "D-Bus doesn't support reserved maybe type in signatures");
+      }
       var data = utf8.encode(value.value);
       writeByte(data.length);
       for (var d in data) {
@@ -182,6 +186,8 @@ class DBusWriteBuffer extends DBusBuffer {
       var childValue = value.value;
       writeValue(childValue.signature);
       writeValue(childValue);
+    } else if (value is DBusMaybe) {
+      throw UnsupportedError("D-Bus doesn't support reserved maybe type");
     } else if (value is DBusStruct) {
       align(STRUCT_ALIGNMENT);
       var children = value.children;
@@ -222,6 +228,8 @@ class DBusWriteBuffer extends DBusBuffer {
       data[lengthOffset + 1] = (length >> 8) & 0xFF;
       data[lengthOffset + 2] = (length >> 16) & 0xFF;
       data[lengthOffset + 3] = (length >> 24) & 0xFF;
+    } else {
+      throw 'Unknown D-Bus value: $value';
     }
   }
 


### PR DESCRIPTION
This is reserved in the D-Bus specification, but not supported at this time.
Added here as it is used in GVariant code, which ideally shared the same classes as dbus.dart.
We may want to move these classes into a gvariant.dart project in the future.