### PR TITLE
Move the dict key signature check to encoding/decoding.

### DIFF
--- a/lib/src/dbus_read_buffer.dart
+++ b/lib/src/dbus_read_buffer.dart
@@ -494,7 +494,12 @@ class DBusReadBuffer extends DBusBuffer {
       if (signatures.length != 2) {
         throw 'Invalid dict signature ${childSignature.value}';
       }
-      return readDBusDict(signatures[0], signatures[1], endian);
+      var keySignature = signatures[0];
+      var valueSignature = signatures[1];
+      if (!keySignature.isBasic) {
+        throw 'Invalid dict key signature ${keySignature.value}';
+      }
+      return readDBusDict(keySignature, valueSignature, endian);
     } else if (s.startsWith('a')) {
       return readDBusArray(DBusSignature(s.substring(1, s.length)), endian);
     } else if (s.startsWith('(') && s.endsWith(')')) {

--- a/lib/src/dbus_value.dart
+++ b/lib/src/dbus_value.dart
@@ -641,6 +641,11 @@ class DBusMaybe extends DBusValue {
 
   /// Creates a new D-Bus maybe containing [value].
   DBusMaybe(this.valueSignature, this.value) {
+    if (!valueSignature.isSingleCompleteType) {
+      throw ArgumentError.value(valueSignature, 'valueSignature',
+          'Maybe value type must be a single complete type');
+    }
+
     if (value != null && value!.signature.value != valueSignature.value) {
       throw ArgumentError.value(
           value, 'value', "Value doesn't match signature $valueSignature");
@@ -853,15 +858,15 @@ class DBusDict extends DBusValue {
   final Map<DBusValue, DBusValue> children;
 
   /// Creates a new dictionary with keys of the type [keySignature] and values of the type [valueSignature].
-  /// [keySignature] must contain a single basic type, i.e. byte, boolean, int16, uint16, int32, uint32, int64, uint64, double or unix_fd.
-  /// Container types are not allowed as keys.
-  /// [valueSignature] must contain a single type.
+  /// [keySignature] and [valueSignature] must a single type.
+  /// D-Bus doesn't allow sending and receiving dicts with keys that not basic types, i.e. byte, boolean, int16, uint16, int32, uint32, int64, uint64, double or unix_fd.
+  /// An exception will be thrown when sending a message containing dicts using other types for keys.
   ///
   /// An exception will be thrown if the DBusValues in [children] don't have signatures matching [keySignature] and [valueSignature].
   DBusDict(this.keySignature, this.valueSignature, [this.children = const {}]) {
-    if (!keySignature.isBasic) {
+    if (!keySignature.isSingleCompleteType) {
       throw ArgumentError.value(keySignature, 'keySignature',
-          'Only basic key types are allowed in dicts');
+          'Dict key type must be a single complete type');
     }
     if (!valueSignature.isSingleCompleteType) {
       throw ArgumentError.value(valueSignature, 'valueSignature',

--- a/lib/src/dbus_write_buffer.dart
+++ b/lib/src/dbus_write_buffer.dart
@@ -212,6 +212,11 @@ class DBusWriteBuffer extends DBusBuffer {
       data[lengthOffset + 2] = (length >> 16) & 0xFF;
       data[lengthOffset + 3] = (length >> 24) & 0xFF;
     } else if (value is DBusDict) {
+      if (!value.keySignature.isBasic) {
+        throw UnsupportedError(
+            "D-Bus doesn't support dicts with non basic key types");
+      }
+
       // Length will be overwritten later.
       writeValue(DBusUint32(0));
       var lengthOffset = data.length - 4;


### PR DESCRIPTION
This allows DBusDict to be used in GVariant code which allows non-basic types for keys.