### PR TITLE
Make emitSignal async, as it may need to do a connect to send a signal.

### DIFF
--- a/lib/src/dbus_code_generator.dart
+++ b/lib/src/dbus_code_generator.dart
@@ -273,9 +273,9 @@ class DBusCodeGenerator {
 
     var source = '';
     source += '  /// Emits signal ${interface.name}.${signal.name}\n';
-    source += '  void $methodName(${argsList.join(', ')}) {\n';
+    source += '  Future<void> $methodName(${argsList.join(', ')}) async {\n';
     source +=
-        "     emitSignal('${interface.name}', '${signal.name}', [${argValues.join(', ')}]);\n";
+        "     await emitSignal('${interface.name}', '${signal.name}', [${argValues.join(', ')}]);\n";
     source += '  }\n';
 
     return source;

--- a/lib/src/dbus_object.dart
+++ b/lib/src/dbus_object.dart
@@ -49,17 +49,17 @@ class DBusObject {
   }
 
   /// Emits a signal on this object.
-  void emitSignal(String interface, String name,
-      [Iterable<DBusValue> values = const []]) {
-    client?.emitSignal(
+  Future<void> emitSignal(String interface, String name,
+      [Iterable<DBusValue> values = const []]) async {
+    await client?.emitSignal(
         path: path, interface: interface, name: name, values: values);
   }
 
   /// Emits org.freedesktop.DBus.Properties.PropertiesChanged on this object.
-  void emitPropertiesChanged(String interface,
+  Future<void> emitPropertiesChanged(String interface,
       {Map<String, DBusValue> changedProperties = const {},
-      List<String> invalidatedProperties = const []}) {
-    emitSignal('org.freedesktop.DBus.Properties', 'PropertiesChanged', [
+      List<String> invalidatedProperties = const []}) async {
+    await emitSignal('org.freedesktop.DBus.Properties', 'PropertiesChanged', [
       DBusString(interface),
       DBusDict(
           DBusSignature('s'),
@@ -74,8 +74,8 @@ class DBusObject {
   /// Emits org.freedesktop.DBus.ObjectManager.InterfacesAdded on this object.
   /// [path] is the path to the object that has been added or changed.
   /// [interfacesAndProperties] is the interfaces added to the object at [path] and the properties this object has.
-  void emitInterfacesAdded(DBusObjectPath path,
-      Map<String, Map<String, DBusValue>> interfacesAndProperties) {
+  Future<void> emitInterfacesAdded(DBusObjectPath path,
+      Map<String, Map<String, DBusValue>> interfacesAndProperties) async {
     DBusValue encodeProperties(Map<String, DBusValue> properties) => DBusDict(
         DBusSignature('s'),
         DBusSignature('v'),
@@ -89,15 +89,17 @@ class DBusObject {
             interfacesAndProperties.map<DBusValue, DBusValue>(
                 (name, properties) =>
                     MapEntry(DBusString(name), encodeProperties(properties))));
-    emitSignal('org.freedesktop.DBus.ObjectManager', 'InterfacesAdded',
+    await emitSignal('org.freedesktop.DBus.ObjectManager', 'InterfacesAdded',
         [path, encodeInterfacesAndProperties(interfacesAndProperties)]);
   }
 
   /// Emits org.freedesktop.DBus.ObjectManager.InterfacesRemoved on this object.
   /// [path] is the path to the object is being removed or changed.
   /// [interfaces] is the names of the interfaces being removed from the object at [path].
-  void emitInterfacesRemoved(DBusObjectPath path, Iterable<String> interfaces) {
-    emitSignal('org.freedesktop.DBus.ObjectManager', 'InterfacesRemoved', [
+  Future<void> emitInterfacesRemoved(
+      DBusObjectPath path, Iterable<String> interfaces) async {
+    await emitSignal(
+        'org.freedesktop.DBus.ObjectManager', 'InterfacesRemoved', [
       path,
       DBusArray(DBusSignature('s'),
           interfaces.map((interface) => DBusString(interface)))

--- a/test/generated-code/signal-multiple-args.server.out
+++ b/test/generated-code/signal-multiple-args.server.out
@@ -5,8 +5,8 @@ class ComExampleTest extends DBusObject {
   ComExampleTest({DBusObjectPath path = const DBusObjectPath.unchecked('/')}) : super(path);
 
   /// Emits signal com.example.Test.Event
-  void emitEvent(int byte_value, bool boolean_value, int int16_value, int uint16_value, int int32_value, int uint32_value, int int64_value, int uint64_value, double double_value, String string_value, String object_path_value, DBusValue signature_value, DBusValue variant_value, DBusStruct struct_value, List<int> array_value, Map<String, DBusValue> dict_value) {
-     emitSignal('com.example.Test', 'Event', [DBusByte(byte_value), DBusBoolean(boolean_value), DBusInt16(int16_value), DBusUint16(uint16_value), DBusInt32(int32_value), DBusUint32(uint32_value), DBusInt64(int64_value), DBusUint64(uint64_value), DBusDouble(double_value), DBusString(string_value), DBusObjectPath(object_path_value), signature_value, DBusVariant(variant_value), struct_value, DBusArray.byte(array_value), DBusDict.stringVariant(dict_value)]);
+  Future<void> emitEvent(int byte_value, bool boolean_value, int int16_value, int uint16_value, int int32_value, int uint32_value, int int64_value, int uint64_value, double double_value, String string_value, String object_path_value, DBusValue signature_value, DBusValue variant_value, DBusStruct struct_value, List<int> array_value, Map<String, DBusValue> dict_value) async {
+     await emitSignal('com.example.Test', 'Event', [DBusByte(byte_value), DBusBoolean(boolean_value), DBusInt16(int16_value), DBusUint16(uint16_value), DBusInt32(int32_value), DBusUint32(uint32_value), DBusInt64(int64_value), DBusUint64(uint64_value), DBusDouble(double_value), DBusString(string_value), DBusObjectPath(object_path_value), signature_value, DBusVariant(variant_value), struct_value, DBusArray.byte(array_value), DBusDict.stringVariant(dict_value)]);
   }
 
   @override

--- a/test/generated-code/signal-no-args.server.out
+++ b/test/generated-code/signal-no-args.server.out
@@ -5,8 +5,8 @@ class ComExampleTest extends DBusObject {
   ComExampleTest({DBusObjectPath path = const DBusObjectPath.unchecked('/')}) : super(path);
 
   /// Emits signal com.example.Test.Event
-  void emitEvent() {
-     emitSignal('com.example.Test', 'Event', []);
+  Future<void> emitEvent() async {
+     await emitSignal('com.example.Test', 'Event', []);
   }
 
   @override

--- a/test/generated-code/signal-single-arg.server.out
+++ b/test/generated-code/signal-single-arg.server.out
@@ -5,8 +5,8 @@ class ComExampleTest extends DBusObject {
   ComExampleTest({DBusObjectPath path = const DBusObjectPath.unchecked('/')}) : super(path);
 
   /// Emits signal com.example.Test.Event
-  void emitEvent(String value) {
-     emitSignal('com.example.Test', 'Event', [DBusString(value)]);
+  Future<void> emitEvent(String value) async {
+     await emitSignal('com.example.Test', 'Event', [DBusString(value)]);
   }
 
   @override

--- a/test/generated-code/signals.server.out
+++ b/test/generated-code/signals.server.out
@@ -5,13 +5,13 @@ class ComExampleTest extends DBusObject {
   ComExampleTest({DBusObjectPath path = const DBusObjectPath.unchecked('/')}) : super(path);
 
   /// Emits signal com.example.Test.Event1
-  void emitEvent1(String value) {
-     emitSignal('com.example.Test', 'Event1', [DBusString(value)]);
+  Future<void> emitEvent1(String value) async {
+     await emitSignal('com.example.Test', 'Event1', [DBusString(value)]);
   }
 
   /// Emits signal com.example.Test.Event2
-  void emitEvent2(int value) {
-     emitSignal('com.example.Test', 'Event2', [DBusInt32(value)]);
+  Future<void> emitEvent2(int value) async {
+     await emitSignal('com.example.Test', 'Event2', [DBusInt32(value)]);
   }
 
   @override


### PR DESCRIPTION
This fixes an issue where a signal emitted during a method call is not received until after the call completes.

This is an API break.