### PR TITLE
Check for IPv6 support before attempting tests.

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -29,4 +29,4 @@ jobs:
         run: dart analyze --fatal-infos --fatal-warnings .
 
       - name: Run regression tests
-        run: dart test -x ipv6
+        run: dart test

--- a/test/dbus_test.dart
+++ b/test/dbus_test.dart
@@ -620,6 +620,15 @@ void main() {
   });
 
   test('ping - ipv6 tcp', () async {
+    // Check if IPv6 support is available on this host, otherwise skip the test.
+    try {
+      var socket = await ServerSocket.bind(InternetAddress.loopbackIPv6, 0);
+      await socket.close();
+    } on SocketException {
+      markTestSkipped('IPv6 support not available');
+      return;
+    }
+
     var server = DBusServer();
     var address = await server.listenAddress(
         DBusAddress.tcp('localhost', family: DBusAddressTcpFamily.ipv6));
@@ -631,7 +640,7 @@ void main() {
 
     // Check can ping the server.
     await client.ping();
-  }, tags: ['ipv6']);
+  });
 
   test('list names', () async {
     var server = DBusServer();


### PR DESCRIPTION
This replaces the explicit flag.