### PR TITLE
Catch exceptions reading from sockets.

### DIFF
--- a/lib/src/dbus_client.dart
+++ b/lib/src/dbus_client.dart
@@ -726,7 +726,8 @@ class DBusClient {
     }
 
     _socket = await Socket.connect(socketAddress, port);
-    _socket?.listen(_processData);
+    _socket?.listen(_processData,
+        onError: (error) {}, onDone: () => _socket!.close());
   }
 
   /// Performs authentication with D-Bus server.

--- a/lib/src/dbus_server.dart
+++ b/lib/src/dbus_server.dart
@@ -78,7 +78,8 @@ class _DBusRemoteClient {
   _DBusRemoteClient(this.serverSocket, this._socket, this.uniqueName)
       : _authServer = DBusAuthServer(serverSocket.uuid) {
     _authServer.responses.listen((message) => _socket.write(message + '\r\n'));
-    _socket.listen(_processData);
+    _socket.listen(_processData,
+        onError: (error) {}, onDone: () => _socket.close());
   }
 
   /// True if this client has a rule that matches [message].
@@ -192,7 +193,7 @@ class _DBusServerSocket {
       var uniqueName = DBusBusName(':$connectionId.$_nextClientId');
       _nextClientId++;
       _clients.add(_DBusRemoteClient(this, clientSocket, uniqueName));
-    });
+    }, onError: (error) {}, onDone: () => socket.close());
   }
 
   Future<void> close() async {


### PR DESCRIPTION
If the error is not handled or the socket not closed the whole Dart process will close due to an unhandled exception.