### PR TITLE
Added required name and path attributes to generated remote object constructor

### DIFF
--- a/lib/src/dbus_code_generator.dart
+++ b/lib/src/dbus_code_generator.dart
@@ -582,7 +582,7 @@ class DBusCodeGenerator {
     }
 
     var constructor =
-        '  $className(DBusClient client, String destination, $pathArg) : super(client, destination, path)';
+        '  $className(DBusClient client, String destination, $pathArg) : super(client, name: destination, path: path)';
     if (variableConstructors.isEmpty) {
       constructor += ';\n';
     } else {

--- a/test/generated-code/method-multiple-inputs.client.out
+++ b/test/generated-code/method-multiple-inputs.client.out
@@ -1,7 +1,7 @@
 import 'package:dbus/dbus.dart';
 
 class ComExampleTest extends DBusRemoteObject {
-  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path);
+  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, name: destination, path: path);
 
   /// Invokes com.example.Test.Hello()
   Future<void> callHello(int byte_value, bool boolean_value, int int16_value, int uint16_value, int int32_value, int uint32_value, int int64_value, int uint64_value, double double_value, String string_value, String object_path_value, DBusValue signature_value, DBusValue variant_value, DBusStruct struct_value, List<int> array_value, Map<String, DBusValue> dict_value, {bool noAutoStart = false, bool allowInteractiveAuthorization = false}) async {

--- a/test/generated-code/method-multiple-outputs.client.out
+++ b/test/generated-code/method-multiple-outputs.client.out
@@ -1,7 +1,7 @@
 import 'package:dbus/dbus.dart';
 
 class ComExampleTest extends DBusRemoteObject {
-  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path);
+  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, name: destination, path: path);
 
   /// Invokes com.example.Test.Hello()
   Future<List<DBusValue>> callHello({bool noAutoStart = false, bool allowInteractiveAuthorization = false}) async {

--- a/test/generated-code/method-no-args.client.out
+++ b/test/generated-code/method-no-args.client.out
@@ -1,7 +1,7 @@
 import 'package:dbus/dbus.dart';
 
 class ComExampleTest extends DBusRemoteObject {
-  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path);
+  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, name: destination, path: path);
 
   /// Invokes com.example.Test.Hello()
   Future<void> callHello({bool noAutoStart = false, bool allowInteractiveAuthorization = false}) async {

--- a/test/generated-code/method-no-reply.client.out
+++ b/test/generated-code/method-no-reply.client.out
@@ -1,7 +1,7 @@
 import 'package:dbus/dbus.dart';
 
 class ComExampleTest extends DBusRemoteObject {
-  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path);
+  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, name: destination, path: path);
 
   /// Invokes com.example.Test.Hello()
   Future<void> callHello(String value, {bool noAutoStart = false, bool allowInteractiveAuthorization = false}) async {

--- a/test/generated-code/method-single-input.client.out
+++ b/test/generated-code/method-single-input.client.out
@@ -1,7 +1,7 @@
 import 'package:dbus/dbus.dart';
 
 class ComExampleTest extends DBusRemoteObject {
-  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path);
+  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, name: destination, path: path);
 
   /// Invokes com.example.Test.Hello()
   Future<void> callHello(String value, {bool noAutoStart = false, bool allowInteractiveAuthorization = false}) async {

--- a/test/generated-code/method-single-output.client.out
+++ b/test/generated-code/method-single-output.client.out
@@ -1,7 +1,7 @@
 import 'package:dbus/dbus.dart';
 
 class ComExampleTest extends DBusRemoteObject {
-  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path);
+  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, name: destination, path: path);
 
   /// Invokes com.example.Test.Hello()
   Future<String> callHello({bool noAutoStart = false, bool allowInteractiveAuthorization = false}) async {

--- a/test/generated-code/method-unnamed-arg.client.out
+++ b/test/generated-code/method-unnamed-arg.client.out
@@ -1,7 +1,7 @@
 import 'package:dbus/dbus.dart';
 
 class ComExampleTest extends DBusRemoteObject {
-  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path);
+  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, name: destination, path: path);
 
   /// Invokes com.example.Test.Hello()
   Future<void> callHello(String arg_0, {bool noAutoStart = false, bool allowInteractiveAuthorization = false}) async {

--- a/test/generated-code/methods.client.out
+++ b/test/generated-code/methods.client.out
@@ -1,7 +1,7 @@
 import 'package:dbus/dbus.dart';
 
 class ComExampleTest extends DBusRemoteObject {
-  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path);
+  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, name: destination, path: path);
 
   /// Invokes com.example.Test.Hello1()
   Future<void> callHello1({bool noAutoStart = false, bool allowInteractiveAuthorization = false}) async {

--- a/test/generated-code/multiple-interfaces.client.out
+++ b/test/generated-code/multiple-interfaces.client.out
@@ -1,7 +1,7 @@
 import 'package:dbus/dbus.dart';
 
 class ComExampleTest1 extends DBusRemoteObject {
-  ComExampleTest1(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path);
+  ComExampleTest1(DBusClient client, String destination, DBusObjectPath path) : super(client, name: destination, path: path);
 
   /// Invokes com.example.Test1.Hello()
   Future<void> callHello({bool noAutoStart = false, bool allowInteractiveAuthorization = false}) async {

--- a/test/generated-code/properties.client.out
+++ b/test/generated-code/properties.client.out
@@ -1,7 +1,7 @@
 import 'package:dbus/dbus.dart';
 
 class ComExampleTest extends DBusRemoteObject {
-  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path);
+  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, name: destination, path: path);
 
   /// Gets com.example.Test.ByteProperty
   Future<int> getByteProperty() async {

--- a/test/generated-code/property-access.client.out
+++ b/test/generated-code/property-access.client.out
@@ -1,7 +1,7 @@
 import 'package:dbus/dbus.dart';
 
 class ComExampleTest extends DBusRemoteObject {
-  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path);
+  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, name: destination, path: path);
 
   /// Gets com.example.Test.ReadProperty
   Future<int> getReadProperty() async {

--- a/test/generated-code/property.client.out
+++ b/test/generated-code/property.client.out
@@ -1,7 +1,7 @@
 import 'package:dbus/dbus.dart';
 
 class ComExampleTest extends DBusRemoteObject {
-  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path);
+  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, name: destination, path: path);
 
   /// Gets com.example.Test.Value
   Future<String> getValue() async {

--- a/test/generated-code/signal-multiple-args.client.out
+++ b/test/generated-code/signal-multiple-args.client.out
@@ -26,7 +26,7 @@ class ComExampleTest extends DBusRemoteObject {
   /// Stream of com.example.Test.Event signals.
   late final Stream<ComExampleTestEvent> event;
 
-  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path) {
+  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, name: destination, path: path) {
     event = DBusRemoteObjectSignalStream(object: this, interface: 'com.example.Test', name: 'Event', signature: DBusSignature('ybnqiuxtdsogv(si)aya{sv}')).map((signal) => ComExampleTestEvent(signal));
   }
 }

--- a/test/generated-code/signal-no-args.client.out
+++ b/test/generated-code/signal-no-args.client.out
@@ -9,7 +9,7 @@ class ComExampleTest extends DBusRemoteObject {
   /// Stream of com.example.Test.Event signals.
   late final Stream<ComExampleTestEvent> event;
 
-  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path) {
+  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, name: destination, path: path) {
     event = DBusRemoteObjectSignalStream(object: this, interface: 'com.example.Test', name: 'Event', signature: DBusSignature('')).map((signal) => ComExampleTestEvent(signal));
   }
 }

--- a/test/generated-code/signal-single-arg.client.out
+++ b/test/generated-code/signal-single-arg.client.out
@@ -11,7 +11,7 @@ class ComExampleTest extends DBusRemoteObject {
   /// Stream of com.example.Test.Event signals.
   late final Stream<ComExampleTestEvent> event;
 
-  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path) {
+  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, name: destination, path: path) {
     event = DBusRemoteObjectSignalStream(object: this, interface: 'com.example.Test', name: 'Event', signature: DBusSignature('s')).map((signal) => ComExampleTestEvent(signal));
   }
 }

--- a/test/generated-code/signals.client.out
+++ b/test/generated-code/signals.client.out
@@ -21,7 +21,7 @@ class ComExampleTest extends DBusRemoteObject {
   /// Stream of com.example.Test.Event2 signals.
   late final Stream<ComExampleTestEvent2> event2;
 
-  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path) {
+  ComExampleTest(DBusClient client, String destination, DBusObjectPath path) : super(client, name: destination, path: path) {
     event1 = DBusRemoteObjectSignalStream(object: this, interface: 'com.example.Test', name: 'Event1', signature: DBusSignature('s')).map((signal) => ComExampleTestEvent1(signal));
 
     event2 = DBusRemoteObjectSignalStream(object: this, interface: 'com.example.Test', name: 'Event2', signature: DBusSignature('i')).map((signal) => ComExampleTestEvent2(signal));


### PR DESCRIPTION
Right now compilations are failing for any examples on `dbus: ^0.6.3` because the remote object constructor has made name and path a required named attribute.