### PR TITLE
Fix typo and missing constructor in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,7 @@ await client.close();
 import 'package:dbus/dbus.dart';
 
 class TestObject extends DBusObject {
-  @override
-  DBusObjectPath get path {
-    return DBusObjectPath('/com/example/Test');
-  }
+  TestObject() : super(DBusObjectPath('/com/example/Test'));
 
   @override
   Future<DBusMethodResponse> handleMethodCall(DBusMethodCall methodCall) async {

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ class TestObject extends DBusObject {
   }
 
   @override
-  Future<MethodResponse> handleMethodCall(DBusMethodCall methodCall) async {
+  Future<DBusMethodResponse> handleMethodCall(DBusMethodCall methodCall) async {
     if (methodCall.interface == 'com.example.Test') {
       if (methodCall.name == 'Test') {
         return DBusMethodSuccessResponse([DBusString('Hello World!')]);


### PR DESCRIPTION
* The example in the README.md file incorrectly cites `Future<MethodResponse>` as the return type of `handleMethodCall`. This should be `Future<DBusMethodResponse>`.
* Dart complains when using the README.md example as-is because the `TestObject` class is missing a parameter-less constructor.