### PR TITLE
Drop dependency on deprecated pedantic plugin

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,10 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    - always_declare_return_types
+    - prefer_single_quotes
+    - sort_child_properties_last
+    - unawaited_futures
+    - unsafe_html
+    - use_full_hex_values_for_flutter_colors

--- a/lib/src/dbus_client.dart
+++ b/lib/src/dbus_client.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:pedantic/pedantic.dart';
-
 import 'dbus_address.dart';
 import 'dbus_auth_client.dart';
 import 'dbus_bus_name.dart';

--- a/lib/src/dbus_server.dart
+++ b/lib/src/dbus_server.dart
@@ -3,8 +3,6 @@ import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
 
-import 'package:pedantic/pedantic.dart';
-
 import 'dbus_address.dart';
 import 'dbus_auth_server.dart';
 import 'dbus_bus_name.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,10 +14,10 @@ dependencies:
   args: ^2.0.0
   ffi: ^1.1.2
   meta: ^1.3.0
-  pedantic: ^1.9.0
   xml: ^5.0.0
 
 dev_dependencies:
+  lints: ^1.0.1
   test: ^1.16.8
   test_cov: ^1.0.1
 


### PR DESCRIPTION
Pedantic is deprecated upstream. Drop support and switch to equivalent `lints` package with appropriate configuration to match `pedantic`'s default rule set.
