### PR TITLE
DBusIntrospectAnnotation.toXml() was creating <method> elements

### DIFF
--- a/lib/src/dbus_introspect.dart
+++ b/lib/src/dbus_introspect.dart
@@ -466,7 +466,7 @@ class DBusIntrospectAnnotation {
   }
 
   XmlNode toXml() {
-    return XmlElement(XmlName('method'), [
+    return XmlElement(XmlName('annotation'), [
       XmlAttribute(XmlName('name'), name),
       XmlAttribute(XmlName('value'), value)
     ]);


### PR DESCRIPTION
Aside from failing to annotate, this bug crashes D-Feet and causes `gdbus introspect` to report invalid XML. Both D-Feet and gdbus work as expected after this fix is made.