### PR TITLE
Replace unawaited calls with ignore comments.

### DIFF
--- a/lib/src/dbus_client.dart
+++ b/lib/src/dbus_client.dart
@@ -788,9 +788,10 @@ class DBusClient {
     if (_socket != null) {
       _socket!.listen(_processData,
           onError: (error) {}, onDone: () => _socket!.close());
-      unawaited(_socket!.done.then((value) {
+      // ignore: unawaited_futures
+      _socket!.done.then((value) {
         _socketClosed = true;
-      }));
+      });
     }
   }
 

--- a/lib/src/dbus_server.dart
+++ b/lib/src/dbus_server.dart
@@ -534,7 +534,8 @@ class DBusServer {
           sender: DBusBusName('org.freedesktop.DBus'),
           values: values);
       _nextSerial++;
-      unawaited(_processMessage(null, responseMessage));
+      // ignore: unawaited_futures
+      _processMessage(null, responseMessage);
     }
   }
 
@@ -1254,7 +1255,7 @@ class DBusServer {
         sender: DBusBusName('org.freedesktop.DBus'),
         values: values.toList());
     _nextSerial++;
-    unawaited(_processMessage(null, message));
+    _processMessage(null, message);
   }
 
   @override


### PR DESCRIPTION
unawaited() was in dart:pedantic, which is now deprecated. It is in
dart:async 2.14, but we don't want to depend on that. Instead, use
a comment to ignore these linting issues.

Fixes https://github.com/canonical/dbus.dart/issues/304