### PR TITLE
Broadcast D-Bus signal stream

### DIFF
--- a/lib/src/dbus_client.dart
+++ b/lib/src/dbus_client.dart
@@ -89,7 +89,7 @@ class DBusSignalStream extends Stream<DBusSignal> {
   final DBusClient _client;
   final DBusMatchRule _rule;
   final DBusSignature? _signature;
-  final _controller = StreamController<DBusSignal>();
+  final _controller = StreamController<DBusSignal>.broadcast();
 
   /// Creates a stream of signals that match [sender], [interface], [name], [path] and/or [pathNamespace].
   ///


### PR DESCRIPTION
Fixes half of the issue described in https://github.com/canonical/dbus.dart/issues/293#issuecomment-986817974:

```
StateError: Bad state: Stream has already been listened to.
#0      _StreamController._subscribe (dart:async/stream_controller.dart:635:7)
#1      _ControllerStream._createSubscription (dart:async/stream_controller.dart:786:19)
#2      _StreamImpl.listen (dart:async/stream_impl.dart:473:9)
#3      DBusSignalStream.listen
#4      new _ForwardingStreamSubscription (dart:async/stream_pipe.dart:114:10)
#5      _ForwardingStream._createSubscription (dart:async/stream_pipe.dart:86:16)
#6      _ForwardingStream.listen (dart:async/stream_pipe.dart:81:12)
#7      NetworkManagerClient.connect
```