### PR TITLE
Fix DBusClient._removeMatch()

### DIFF
--- a/lib/src/dbus_client.dart
+++ b/lib/src/dbus_client.dart
@@ -872,6 +872,7 @@ class DBusClient {
     }
 
     if (count == 1) {
+      _matchRules.remove(rule);
       if (!_socketClosed) {
         await callMethod(
             destination: 'org.freedesktop.DBus',
@@ -881,7 +882,6 @@ class DBusClient {
             values: [DBusString(rule)],
             replySignature: DBusSignature(''));
       }
-      _matchRules.remove(rule);
     } else {
       _matchRules[rule] = count - 1;
     }


### PR DESCRIPTION
Fixes the other half of the issue described in #293 (comment):

```dart
import 'package:dbus/dbus.dart';
import 'package:nm/nm.dart';

void main() async {
  final bus = DBusClient.system();
  final client = NetworkManagerClient(bus: bus);

  await client.connect();
  print('Running NetworkManager ${client.version}');
  await client.close();

  await client.connect();
  print('Running NetworkManager ${client.version}');
  await client.close();

  await bus.close();
}
```

```
Unhandled exception:
Attempted to remove match that is not added: type='signal',sender='org.freedesktop.NetworkManager',path_namespace='/org/freedesktop'
#0      DBusClient._removeMatch
package:dbus/src/dbus_client.dart:871
#1      DBusSignalStream._onCancel
package:dbus/src/dbus_client.dart:138
#2      _runGuarded (dart:async/stream_controller.dart:773:24)
#3      _BroadcastStreamController._callOnCancel (dart:async/broadcast_stream_controller.dart:351:5)
#4      _BroadcastStreamController._recordCancel (dart:async/broadcast_stream_controller.dart:223:9)
#5      _ControllerSubscription._onCancel (dart:async/stream_controller.dart:809:24)
#6      _BufferingStreamSubscription._cancel (dart:async/stream_impl.dart:252:21)
#7      _BufferingStreamSubscription.cancel (dart:async/stream_impl.dart:198:7)
#8      _ForwardingStreamSubscription._onCancel (dart:async/stream_pipe.dart:145:27)
#9      _BufferingStreamSubscription._cancel (dart:async/stream_impl.dart:252:21)
#10     _BufferingStreamSubscription.cancel (dart:async/stream_impl.dart:198:7)
#11     NetworkManagerClient.close
package:nm/src/network_manager_client.dart:2586
```

Related issue: #293