### PR TITLE
Explicitly close the socket when the remote end is closed.

### DIFF
--- a/lib/src/dbus_client.dart
+++ b/lib/src/dbus_client.dart
@@ -791,6 +791,7 @@ class DBusClient {
       } else if (event == RawSocketEvent.closed ||
           event == RawSocketEvent.readClosed) {
         _socketClosed = true;
+        _socket?.close();
       }
     });
   }


### PR DESCRIPTION
The Dart process doesn't terminate if this socket remains open, which is resolved if DBusClient.close() is called.
This change matches the older behaviour before RawSocket was used.

Fixes https://github.com/canonical/dbus.dart/issues/323