### PR TITLE
Use contents of DBusStruct/Array/Dict for hash codes.

### DIFF
--- a/lib/src/dbus_value.dart
+++ b/lib/src/dbus_value.dart
@@ -862,7 +862,7 @@ class DBusStruct extends DBusValue {
       other is DBusStruct && _listsEqual(other.children, children);
 
   @override
-  int get hashCode => children.hashCode;
+  int get hashCode => Object.hashAll(children);
 
   @override
   String toString() {
@@ -1045,7 +1045,7 @@ class DBusArray extends DBusValue {
       _listsEqual(other.children, children);
 
   @override
-  int get hashCode => children.hashCode;
+  int get hashCode => Object.hashAll(children);
 
   @override
   String toString() {
@@ -1181,7 +1181,8 @@ class DBusDict extends DBusValue {
       _mapsEqual(other.children, children);
 
   @override
-  int get hashCode => children.hashCode;
+  int get hashCode => Object.hashAll(
+      children.entries.map((entry) => Object.hash(entry.key, entry.value)));
 
   @override
   String toString() {

--- a/test/dbus_test.dart
+++ b/test/dbus_test.dart
@@ -662,6 +662,11 @@ void main() {
           DBusSignature.uint32,
           DBusSignature.double
         ])));
+    expect(
+        DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)])
+            .hashCode,
+        equals(DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)])
+            .hashCode));
   });
 
   test('value - array', () async {
@@ -816,6 +821,8 @@ void main() {
         DBusArray.variant(
             [DBusInt32(1), DBusString('two'), DBusDouble(3.14159)]).signature,
         equals(DBusSignature.array(DBusSignature.variant)));
+    expect(DBusArray.string(['one', 'two', 'three']).hashCode,
+        equals(DBusArray.string(['one', 'two', 'three']).hashCode));
   });
 
   test('value - dict', () async {
@@ -939,6 +946,12 @@ void main() {
             .signature,
         equals(
             DBusSignature.dict(DBusSignature.string, DBusSignature.variant)));
+    expect(
+        DBusDict.stringVariant({'one': DBusInt32(1), 'two': DBusDouble(2)})
+            .hashCode,
+        equals(
+            DBusDict.stringVariant({'one': DBusInt32(1), 'two': DBusDouble(2)})
+                .hashCode));
   });
 
   test('uuid', () async {


### PR DESCRIPTION
This helps when checking for equality in tests. These objects are unlikely to be
used as keys so the hash code is probably not likely to be used outside of that.