### PR TITLE
bumped minimum Dart SDK constraint to 2.17

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ description:
 homepage: https://github.com/canonical/dbus.dart
 
 environment:
-  sdk: '>=2.15.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 platforms:
   linux:


### PR DESCRIPTION
0.7.4 declares that it depends `xml` 6.1.0+, which requires a minimum Dart SDK version of 2.17 but `dbus` still says the minimum it needs is 2.15. This PR is to address this so that it properly declares the minimum supported Dart SDK

Two things that came to mind when I noticed this though
1. Potentially `dbus` should've published 0.7.4 as 0.8.0
2. The build actions aren't catching this issue. I'm not that familiar with GitHub but from the workflows I've seen, the containers being referenced point to `dart:stable`. I suspect this could lead to a version drift of the sorts and the repository may need some way to check that the package still supports the minimum Dart SDK version that it advertises