### PR TITLE
Allow clients and servers to operate without names

### DIFF
--- a/lib/src/dbus_client.dart
+++ b/lib/src/dbus_client.dart
@@ -226,6 +226,9 @@ class DBusClient {
   // Names owned by this client. e.g. [ 'com.example.Foo', 'com.example.Bar' ].
   final _ownedNames = <DBusBusName>{};
 
+  // True if this client registers a name on this bus.
+  final bool _acquireName;
+
   // Unique name of this client, e.g. ':42'.
   DBusBusName? _uniqueName;
 
@@ -233,8 +236,14 @@ class DBusClient {
   final bool introspectable;
 
   /// Creates a new DBus client to connect on [address].
-  DBusClient(DBusAddress address, {this.introspectable = true})
-      : _address = address;
+  /// If [acquireName] is false, then no name is acquired from the server.
+  /// This is useful if the server is not a standard bus with multiple clients
+  /// but rather using D-Bus for client to server communication and not client
+  /// to client.
+  DBusClient(DBusAddress address,
+      {this.introspectable = true, bool acquireName = true})
+      : _address = address,
+        _acquireName = acquireName;
 
   /// Creates a new DBus client to communicate with the system bus.
   factory DBusClient.system({bool introspectable = true}) {
@@ -797,13 +806,15 @@ class DBusClient {
     // The first message to the bus must be this call, note requireConnect is
     // false as the _connect call hasn't yet completed and would otherwise have
     // been called again.
-    var result = await _callMethod(
-        destination: DBusBusName('org.freedesktop.DBus'),
-        path: DBusObjectPath('/org/freedesktop/DBus'),
-        interface: DBusInterfaceName('org.freedesktop.DBus'),
-        name: DBusMemberName('Hello'),
-        replySignature: DBusSignature('s'));
-    _uniqueName = DBusBusName(result.returnValues[0].asString());
+    if (_acquireName) {
+      var result = await _callMethod(
+          destination: DBusBusName('org.freedesktop.DBus'),
+          path: DBusObjectPath('/org/freedesktop/DBus'),
+          interface: DBusInterfaceName('org.freedesktop.DBus'),
+          name: DBusMemberName('Hello'),
+          replySignature: DBusSignature('s'));
+      _uniqueName = DBusBusName(result.returnValues[0].asString());
+    }
 
     // Notify anyone else awaiting connection.
     _connectCompleter?.complete();
@@ -811,7 +822,9 @@ class DBusClient {
     // Monitor name ownership so we know what names we have, and can match incoming signals from other clients.
     _nameAcquiredSubscription = nameAcquired.listen((name) {
       var busName = DBusBusName(name);
-      _nameOwners[busName] = _uniqueName!;
+      if (_acquireName) {
+        _nameOwners[busName] = _uniqueName!;
+      }
       _ownedNames.add(busName);
     });
     _nameLostSubscription = nameLost.listen((name) {

--- a/lib/src/dbus_client.dart
+++ b/lib/src/dbus_client.dart
@@ -127,15 +127,19 @@ class DBusSignalStream extends Stream<DBusSignal> {
 
   void _onListen() {
     _client._signalStreams.add(this);
-    if (_rule.sender != null) {
-      _client._findUniqueName(_rule.sender!);
+    if (_client._messageBus) {
+      if (_rule.sender != null) {
+        _client._findUniqueName(_rule.sender!);
+      }
+      _client._addMatch(_rule.toDBusString());
     }
-    _client._addMatch(_rule.toDBusString());
   }
 
   Future<void> _onCancel() async {
-    await _client._removeMatch(_rule.toDBusString());
-    _client._signalStreams.remove(this);
+    if (_client._messageBus) {
+      await _client._removeMatch(_rule.toDBusString());
+      _client._signalStreams.remove(this);
+    }
   }
 }
 

--- a/lib/src/dbus_method_call.dart
+++ b/lib/src/dbus_method_call.dart
@@ -3,7 +3,7 @@ import 'dbus_value.dart';
 /// A D-Bus method call.
 class DBusMethodCall {
   /// Client that called the method.
-  final String sender;
+  final String? sender;
 
   /// Interface method is on.
   final String? interface;
@@ -29,7 +29,7 @@ class DBusMethodCall {
       .fold(DBusSignature(''), (a, b) => a + b);
 
   const DBusMethodCall(
-      {required this.sender,
+      {this.sender,
       this.interface,
       required this.name,
       this.values = const [],

--- a/lib/src/dbus_remote_object.dart
+++ b/lib/src/dbus_remote_object.dart
@@ -67,7 +67,7 @@ class DBusRemoteObject {
   final DBusClient client;
 
   /// The name of the client providing this object.
-  final String name;
+  final String? name;
 
   /// The path to the object.
   final DBusObjectPath path;
@@ -76,7 +76,7 @@ class DBusRemoteObject {
   late final Stream<DBusPropertiesChangedSignal> propertiesChanged;
 
   /// Creates an object that access accesses a remote D-Bus object using bus [name] with [path].
-  DBusRemoteObject(this.client, {required this.name, required this.path}) {
+  DBusRemoteObject(this.client, {this.name, required this.path}) {
     var rawPropertiesChanged = DBusRemoteObjectSignalStream(
         object: this,
         interface: 'org.freedesktop.DBus.Properties',

--- a/test/dbus_test.dart
+++ b/test/dbus_test.dart
@@ -1535,6 +1535,12 @@ void main() {
         path: DBusObjectPath('/com/example/Object1'), name: 'Foo');
     expect(response.values, equals([DBusString('Hello World')]));
 
+    // Call method on server using remote object.
+    var remoteObject =
+        DBusRemoteObject(client, path: DBusObjectPath('/com/example/Object1'));
+    var remoteObjectResponse = await remoteObject.callMethod(null, 'Foo', []);
+    expect(remoteObjectResponse.values, equals([DBusString('Hello World')]));
+
     // Try and access an unknown object.
     expect(
         () => client.callMethod(

--- a/test/dbus_test.dart
+++ b/test/dbus_test.dart
@@ -1512,11 +1512,11 @@ void main() {
         () => client2.ping(name1), throwsA(isA<DBusServiceUnknownException>()));
   });
 
-  test('no acquire name', () async {
-    var server = DBusServer(requireNames: false);
+  test('no message bus', () async {
+    var server = DBusServer(messageBus: false);
     var address =
         await server.listenAddress(DBusAddress.unix(abstract: 'abstract'));
-    var client = DBusClient(address, acquireName: false);
+    var client = DBusClient(address, messageBus: false);
     addTearDown(() async {
       await client.close();
       await server.close();


### PR DESCRIPTION
Allow clients and servers to operate without names, for example if using D-Bus

for a simple client-server relationship and not in the more common client-client.

This only supports method calls from the client to the server at present.