### PR TITLE
Changed Conditional Imports

### DIFF
--- a/lib/src/getsid.dart
+++ b/lib/src/getsid.dart
@@ -1,2 +1,2 @@
 // Conditionally import the FFI version, so this doesn't break web builds.
-export 'getsid_stub.dart' if (dart.library.ffi) 'getsid_windows.dart';
+export 'getsid_stub.dart' if (dart.library.io) 'getsid_windows.dart';

--- a/lib/src/getuid.dart
+++ b/lib/src/getuid.dart
@@ -1,2 +1,2 @@
 // Conditionally import the FFI version, so this doesn't break web builds.
-export 'getuid_stub.dart' if (dart.library.ffi) 'getuid_linux.dart';
+export 'getuid_stub.dart' if (dart.library.io) 'getuid_linux.dart';


### PR DESCRIPTION
During compiling project to WASM I get these errors: 

```
../../../.pub-cache/hosted/pub.dev/dbus-0.7.10/lib/src/getsid_windows.dart:1:1: Error: 'dart:ffi' can't be imported when compiling to Wasm.
import 'dart:ffi';
^
../../../.pub-cache/hosted/pub.dev/dbus-0.7.10/lib/src/getuid_linux.dart:1:1: Error: 'dart:ffi' can't be imported when compiling to Wasm.
import 'dart:ffi';
^
```

Changing conditional imports to **dart.library.io** solves the problem. 
For example: 
```
export 'getsid_stub.dart' if (dart.library.io) 'getsid_windows.dart';
```

As a workaround for now this helps: 
```
 dependency_overrides: 
  dbus: # Till the fix for conditional import merged https://github.com/canonical/dbus.dart/pull/380
    git:
      url: https://github.com/AlexBacich/dbus.dart.git
      ref: a01bb05
```