### PR TITLE
optionally pass auth client to dbus client

### DIFF
--- a/lib/dbus.dart
+++ b/lib/dbus.dart
@@ -1,4 +1,5 @@
 export 'src/dbus_address.dart';
+export 'src/dbus_auth_client.dart';
 export 'src/dbus_client.dart';
 export 'src/dbus_introspect.dart';
 export 'src/dbus_method_call.dart';

--- a/lib/src/dbus_auth_client.dart
+++ b/lib/src/dbus_auth_client.dart
@@ -15,6 +15,7 @@ class DBusAuthClient {
   var _unixFdSupported = false;
   DBusUUID? _uuid;
   String? _errorMessage;
+  final String? _uid;
 
   /// Stream of requests to send to the authentication server.
   Stream<String> get requests => _requestsController.stream;
@@ -35,7 +36,9 @@ class DBusAuthClient {
   String? get errorMessage => _errorMessage;
 
   /// Creates a new authentication client.
-  DBusAuthClient({bool requestUnixFd = true}) : _requestUnixFd = requestUnixFd {
+  DBusAuthClient({bool requestUnixFd = true, String? uid})
+      : _requestUnixFd = requestUnixFd,
+        _uid = uid {
     // On start, end an empty byte, as this is required if sending the credentials as a socket control message.
     // We rely on the server using SO_PEERCRED to check out credentials.
     // Then request the supported mechanisms.
@@ -126,7 +129,9 @@ class DBusAuthClient {
   /// Start authentication using the EXTERNAL mechanism.
   void _authenticateExternal() {
     String authId;
-    if (Platform.isLinux) {
+    if (_uid != null) {
+      authId = _uid!;
+    } else if (Platform.isLinux) {
       authId = getuid().toString();
     } else if (Platform.isWindows) {
       authId = getsid();

--- a/lib/src/dbus_client.dart
+++ b/lib/src/dbus_client.dart
@@ -214,7 +214,7 @@ class DBusClient {
   RawSocket? _socket;
   var _socketClosed = false;
   final _readBuffer = DBusReadBuffer();
-  final _authClient = DBusAuthClient();
+  final DBusAuthClient _authClient;
   var _authComplete = false;
   Completer? _connectCompleter;
   var _lastSerial = 0;
@@ -243,11 +243,15 @@ class DBusClient {
 
   /// Creates a new DBus client to connect on [address].
   /// If [messageBus] is false, then the server is not running a message bus and
-  /// no adresses or client to client communication is suported.
+  /// no addresses or client to client communication is supported.
+  /// If [authClient] is provided, it will be used instead of creating a new one.
   DBusClient(DBusAddress address,
-      {this.introspectable = true, bool messageBus = true})
+      {this.introspectable = true,
+      bool messageBus = true,
+      DBusAuthClient? authClient})
       : _address = address,
-        _messageBus = messageBus;
+        _messageBus = messageBus,
+        _authClient = authClient ?? DBusAuthClient();
 
   /// Creates a new DBus client to communicate with the system bus.
   factory DBusClient.system({bool introspectable = true}) {


### PR DESCRIPTION
Now I am able to connect to remote dbus sessions and authenticating with the default `EXTERNAL` method.

example: 
```dart
Future<DBusClient> connectRemoteSystemBus({
  required String remoteHost,
  required String sshUser,
  required String sshPassword,
  int remotePort = 22,
  int localPort = 7272,
}) async {
  // 1) Start the TCP server that will accept a D-Bus client connection
  final server = await ServerSocket.bind('127.0.0.1', localPort);
  print('Listening locally on ${server.address.address}:${server.port}');

  // 2) Set up the SSH session to run systemd-stdio-bridge on the remote
  final sshSocket = await SSHSocket.connect(remoteHost, remotePort);
  final client = SSHClient(
    sshSocket,
    username: sshUser,
    onPasswordRequest: () => sshPassword,
    onVerifyHostKey: (host, key) => true, // WARNING: verify in production!
  );

  // Start an SSH session that runs "systemd-stdio-bridge"
  final uidSession = await client.execute('id -u');
  final uid = String.fromCharCodes(await uidSession.stdout.first).trim();
  final session = await client.execute('systemd-stdio-bridge');
  print('SSH session started: systemd-stdio-bridge on $remoteHost');

  // 3) Create the DBusClient first
  final dbusAddress = DBusAddress.tcp('127.0.0.1', port: localPort);
  final dbusAuth = DBusAuthClient(uid: uid);
  final dbusClient = DBusClient(dbusAddress, authClient: dbusAuth);
  print(
      'DBusClient created. Will connect to tcp:host=127.0.0.1,port=$localPort');

  // 4) Set up a future for the client connection
  final serverSideSocketFuture = server.first;

  // 5) Make the D-Bus call which will trigger the connection
  print('Attempting D-Bus call: ListNames on org.freedesktop.DBus...');
  final dbusCallFuture = dbusClient.callMethod(
    destination: 'org.freedesktop.DBus',
    path: DBusObjectPath('/org/freedesktop/DBus'),
    interface: 'org.freedesktop.DBus',
    name: 'ListNames',
    replySignature: DBusSignature('as'),
  );

  // 6) Wait for the client to connect
  print('Waiting for client socket connection...');
  final serverSideSocket = await serverSideSocketFuture;
  print('Client connected to local port ${serverSideSocket.port}');

  // 7) Set up the pipes between local socket and SSH session
  serverSideSocket.pipe(session.stdin);
  session.stdout.cast<List<int>>().pipe(serverSideSocket);

  // 8) Now wait for the D-Bus call to complete
  await dbusCallFuture;
  print('D-Bus connection established successfully');

  return dbusClient;
}

```