### PR TITLE
chore: throw an explicit Dart error when running on non-Linux systems

### DIFF
--- a/lib/src/getuid_linux.dart
+++ b/lib/src/getuid_linux.dart
@@ -7,7 +7,8 @@ typedef _GetuidDart = int Function();
 /// Gets the user ID of the current user.
 int getuid() {
   if (!Platform.isLinux) {
-    throw 'Unable to determine UID on this system';
+    throw UnsupportedError(
+        'Unable to determine UID on: ${Platform.operatingSystem}');
   }
 
   final dylib = DynamicLibrary.open('libc.so.6');


### PR DESCRIPTION
The `dbus` package is not meant for non-Linux systems; using it on macOS or Windows should throw an Error (indicating a bug).

The previous code throws a `String` rather than an explicit Dart error (e.g., `ArgumentError`, `UnsupportedError`, `UnimplementedError`). In Dart, at least, errors (not exceptions or failures) are an indication of a bug, and should be solved in code rather than handled using try-catch at runtime.

Throwing a Dart error instead of a String is considered best practice, see also:

* https://dart.dev/tools/linter-rules/only_throw_errors
* https://dart.dev/tools/linter-rules/avoid_catching_errors

Additionally, this also includes the current operating system in the error message to make it easier to debug, so if an error was thrown (incorrect usage or a bug from the developer side), tools like [Sentry](https://pub.dev/packages/sentry) will report it and having a clearer error message, make it easier for the developer to know what the issue is.