### PR TITLE
Fix argument of Map.remove call

### DIFF
--- a/lib/src/dbus_object_tree.dart
+++ b/lib/src/dbus_object_tree.dart
@@ -54,7 +54,7 @@ class DBusObjectTree {
 
     var parent = node.parent;
     if (parent != null) {
-      parent.children.remove(node);
+      parent.children.remove(node.name);
       _prune(parent);
     }
   }


### PR DESCRIPTION
Here's the `children` definition:

```dart
  final children = <String, DBusObjectTreeNode>{};
```

But in ` parent.children.remove(node)` we were passing `DBusObjectTreeNode`, not `String`, and that's wrong. Now everything should be right.