### PR TITLE
Upgrade to xml 7 and new dart

### DIFF
--- a/bin/dart_dbus.dart
+++ b/bin/dart_dbus.dart
@@ -12,25 +12,35 @@ class GenerateObjectCommand extends Command {
   final description = 'Generates a DBusObject to register on the D-Bus.';
 
   GenerateObjectCommand() {
-    argParser.addOption('output',
-        abbr: 'o', valueHelp: 'filename', help: 'Dart file to write to');
-    argParser.addOption('class-name',
-        valueHelp: 'ClassName', help: 'Class name to use');
+    argParser.addOption(
+      'output',
+      abbr: 'o',
+      valueHelp: 'filename',
+      help: 'Dart file to write to',
+    );
+    argParser.addOption(
+      'class-name',
+      valueHelp: 'ClassName',
+      help: 'Class name to use',
+    );
   }
 
   @override
   void run() async {
     if (argResults?.rest.length != 1) {
       usageException(
-          '$name requires a single D-Bus interface file to be provided.');
+        '$name requires a single D-Bus interface file to be provided.',
+      );
     }
     var filename = argResults!.rest[0];
     var node = await loadNode(filename);
     var comment =
         'This file was generated using the following command and may be overwritten.\ndart-dbus $name $filename';
-    var source = DBusCodeGenerator(node,
-            comment: comment, className: argResults?['class-name'])
-        .generateServerSource();
+    var source = DBusCodeGenerator(
+      node,
+      comment: comment,
+      className: argResults?['class-name'],
+    ).generateServerSource();
     await writeSource(source, argResults?['output']);
   }
 }
@@ -45,32 +55,44 @@ class GenerateRemoteObjectCommand extends Command {
       'Generates a DBusRemoteObject to access an object on the D-Bus.';
 
   GenerateRemoteObjectCommand() {
-    argParser.addOption('output',
-        abbr: 'o', valueHelp: 'filename', help: 'Dart file to write to');
-    argParser.addOption('class-name',
-        valueHelp: 'ClassName', help: 'Class name to use');
+    argParser.addOption(
+      'output',
+      abbr: 'o',
+      valueHelp: 'filename',
+      help: 'Dart file to write to',
+    );
+    argParser.addOption(
+      'class-name',
+      valueHelp: 'ClassName',
+      help: 'Class name to use',
+    );
   }
 
   @override
   void run() async {
     if (argResults?.rest.length != 1) {
       usageException(
-          '$name requires a single D-Bus interface file to be provided.');
+        '$name requires a single D-Bus interface file to be provided.',
+      );
     }
     var filename = argResults!.rest[0];
     var node = await loadNode(filename);
     var comment =
         'This file was generated using the following command and may be overwritten.\ndart-dbus $name $filename';
-    var source = DBusCodeGenerator(node,
-            comment: comment, className: argResults?['class-name'])
-        .generateClientSource();
+    var source = DBusCodeGenerator(
+      node,
+      comment: comment,
+      className: argResults?['class-name'],
+    ).generateClientSource();
     await writeSource(source, argResults?['output']);
   }
 }
 
 void main(List<String> args) async {
-  var runner = CommandRunner('dart-dbus',
-      'A tool to generate Dart classes from D-Bus interface defintions.');
+  var runner = CommandRunner(
+    'dart-dbus',
+    'A tool to generate Dart classes from D-Bus interface defintions.',
+  );
   runner.addCommand(GenerateObjectCommand());
   runner.addCommand(GenerateRemoteObjectCommand());
   await runner.run(args).catchError((error) {

--- a/example/credentials.dart
+++ b/example/credentials.dart
@@ -6,14 +6,14 @@ void main() async {
   var client = DBusClient.system();
   var names = await client.listNames();
   var rows = [
-    ['Name', 'PID', 'UID']
+    ['Name', 'PID', 'UID'],
   ];
   for (var name in names) {
     var credentials = await client.getConnectionCredentials(name);
     rows.add([
       name,
       credentials.processId.toString(),
-      credentials.unixUserId.toString()
+      credentials.unixUserId.toString(),
     ]);
   }
   var rowLengths = [0, 0, 0];
@@ -24,7 +24,8 @@ void main() async {
   }
   for (var row in rows) {
     print(
-        '${row[0].padRight(rowLengths[0])} ${row[1].padLeft(rowLengths[1])} ${row[2].padLeft(rowLengths[2])}');
+      '${row[0].padRight(rowLengths[0])} ${row[1].padLeft(rowLengths[1])} ${row[2].padLeft(rowLengths[2])}',
+    );
   }
   await client.close();
 }

--- a/example/example.dart
+++ b/example/example.dart
@@ -2,9 +2,11 @@ import 'package:dbus/dbus.dart';
 
 void main() async {
   var client = DBusClient.session();
-  var object = DBusRemoteObject(client,
-      name: 'org.freedesktop.Notifications',
-      path: DBusObjectPath('/org/freedesktop/Notifications'));
+  var object = DBusRemoteObject(
+    client,
+    name: 'org.freedesktop.Notifications',
+    path: DBusObjectPath('/org/freedesktop/Notifications'),
+  );
   var values = [
     DBusString(''), // App name
     DBusUint32(0), // Replaces
@@ -17,8 +19,11 @@ void main() async {
   ];
   try {
     var result = await object.callMethod(
-        'org.freedesktop.Notifications', 'Notify', values,
-        replySignature: DBusSignature('u'));
+      'org.freedesktop.Notifications',
+      'Notify',
+      values,
+      replySignature: DBusSignature('u'),
+    );
     var id = result.returnValues[0];
     print('notify ${id.toNative()}');
   } on DBusServiceUnknownException {

--- a/example/file_descriptor.dart
+++ b/example/file_descriptor.dart
@@ -9,12 +9,21 @@ class TestObject extends DBusObject {
   @override
   List<DBusIntrospectInterface> introspect() {
     return [
-      DBusIntrospectInterface('com.canonical.DBusDart', methods: [
-        DBusIntrospectMethod('Open', args: [
-          DBusIntrospectArgument(DBusSignature('h'), DBusArgumentDirection.out,
-              name: 'fd')
-        ])
-      ])
+      DBusIntrospectInterface(
+        'com.canonical.DBusDart',
+        methods: [
+          DBusIntrospectMethod(
+            'Open',
+            args: [
+              DBusIntrospectArgument(
+                DBusSignature('h'),
+                DBusArgumentDirection.out,
+                name: 'fd',
+              ),
+            ],
+          ),
+        ],
+      ),
     ];
   }
 
@@ -30,8 +39,9 @@ class TestObject extends DBusObject {
 
       print('Client opens file for reading');
       var file = await File('FD_TEST').open();
-      return DBusMethodSuccessResponse(
-          [DBusUnixFd(ResourceHandle.fromFile(file))]);
+      return DBusMethodSuccessResponse([
+        DBusUnixFd(ResourceHandle.fromFile(file)),
+      ]);
     } else {
       return DBusMethodErrorResponse.unknownMethod();
     }
@@ -46,12 +56,18 @@ void main(List<String> args) async {
     mode = args[0];
   }
   if (mode == 'client') {
-    var object = DBusRemoteObject(client,
-        name: 'com.canonical.DBusDart',
-        path: DBusObjectPath('/com/canonical/DBusDart'));
+    var object = DBusRemoteObject(
+      client,
+      name: 'com.canonical.DBusDart',
+      path: DBusObjectPath('/com/canonical/DBusDart'),
+    );
 
-    var result = await object.callMethod('com.canonical.DBusDart', 'Open', [],
-        replySignature: DBusSignature('h'));
+    var result = await object.callMethod(
+      'com.canonical.DBusDart',
+      'Open',
+      [],
+      replySignature: DBusSignature('h'),
+    );
     var handle = result.returnValues[0].asUnixFd();
     var file = handle.toFile();
 

--- a/example/hostname.dart
+++ b/example/hostname.dart
@@ -2,11 +2,15 @@ import 'package:dbus/dbus.dart';
 
 void main() async {
   var client = DBusClient.system();
-  var object = DBusRemoteObject(client,
-      name: 'org.freedesktop.hostname1',
-      path: DBusObjectPath('/org/freedesktop/hostname1'));
-  var hostname =
-      await object.getProperty('org.freedesktop.hostname1', 'Hostname');
+  var object = DBusRemoteObject(
+    client,
+    name: 'org.freedesktop.hostname1',
+    path: DBusObjectPath('/org/freedesktop/hostname1'),
+  );
+  var hostname = await object.getProperty(
+    'org.freedesktop.hostname1',
+    'Hostname',
+  );
   print('hostname: ${hostname.toNative()}');
   await client.close();
 }

--- a/example/object_manager.dart
+++ b/example/object_manager.dart
@@ -2,9 +2,11 @@ import 'package:dbus/dbus.dart';
 
 void main() async {
   var client = DBusClient.system();
-  var object = DBusRemoteObjectManager(client,
-      name: 'org.freedesktop.NetworkManager',
-      path: DBusObjectPath('/org/freedesktop'));
+  var object = DBusRemoteObjectManager(
+    client,
+    name: 'org.freedesktop.NetworkManager',
+    path: DBusObjectPath('/org/freedesktop'),
+  );
 
   object.signals.listen((signal) {
     if (signal is DBusObjectManagerInterfacesAddedSignal) {
@@ -16,8 +18,9 @@ void main() async {
       }
     } else if (signal is DBusPropertiesChangedSignal) {
       print(signal.path.value);
-      printInterfacesAndProperties(
-          {signal.propertiesInterface: signal.changedProperties});
+      printInterfacesAndProperties({
+        signal.propertiesInterface: signal.changedProperties,
+      });
     }
   });
 
@@ -29,7 +32,8 @@ void main() async {
 }
 
 void printInterfacesAndProperties(
-    Map<String, Map<String, DBusValue>> interfacesAndProperties) {
+  Map<String, Map<String, DBusValue>> interfacesAndProperties,
+) {
   interfacesAndProperties.forEach((interface, properties) {
     print('  $interface');
     properties.forEach((name, value) {

--- a/example/properties.dart
+++ b/example/properties.dart
@@ -2,12 +2,15 @@ import 'package:dbus/dbus.dart';
 
 void main() async {
   var client = DBusClient.system();
-  var object = DBusRemoteObject(client,
-      name: 'org.freedesktop.NetworkManager',
-      path: DBusObjectPath('/org/freedesktop/NetworkManager'));
+  var object = DBusRemoteObject(
+    client,
+    name: 'org.freedesktop.NetworkManager',
+    path: DBusObjectPath('/org/freedesktop/NetworkManager'),
+  );
 
-  var properties =
-      await object.getAllProperties('org.freedesktop.NetworkManager');
+  var properties = await object.getAllProperties(
+    'org.freedesktop.NetworkManager',
+  );
   properties.forEach((name, value) {
     print('$name: ${value.toNative()}');
   });
@@ -16,10 +19,15 @@ void main() async {
   print('Hardware addresses:');
   var devicePaths = properties['Devices']?.asObjectPathArray() ?? [];
   for (var path in devicePaths) {
-    var device = DBusRemoteObject(client,
-        name: 'org.freedesktop.NetworkManager', path: path);
+    var device = DBusRemoteObject(
+      client,
+      name: 'org.freedesktop.NetworkManager',
+      path: path,
+    );
     var address = await device.getProperty(
-        'org.freedesktop.NetworkManager.Device', 'HwAddress');
+      'org.freedesktop.NetworkManager.Device',
+      'HwAddress',
+    );
     print('${address.toNative()}');
   }
 

--- a/example/register_object.dart
+++ b/example/register_object.dart
@@ -11,11 +11,17 @@ class TestObject extends DBusObject {
   @override
   List<DBusIntrospectInterface> introspect() {
     final testMethod = DBusIntrospectMethod('Test');
-    final countProperty = DBusIntrospectProperty('Count', DBusSignature('x'),
-        access: DBusPropertyAccess.read);
+    final countProperty = DBusIntrospectProperty(
+      'Count',
+      DBusSignature('x'),
+      access: DBusPropertyAccess.read,
+    );
     return [
-      DBusIntrospectInterface('com.canonical.DBusDart',
-          methods: [testMethod], properties: [countProperty])
+      DBusIntrospectInterface(
+        'com.canonical.DBusDart',
+        methods: [testMethod],
+        properties: [countProperty],
+      ),
     ];
   }
 
@@ -48,7 +54,10 @@ class TestObject extends DBusObject {
 
   @override
   Future<DBusMethodResponse> setProperty(
-      String interface, String name, DBusValue value) async {
+    String interface,
+    String name,
+    DBusValue value,
+  ) async {
     if (interface != 'com.canonical.DBusDart') {
       return DBusMethodErrorResponse.unknownInterface();
     }

--- a/example/request_name.dart
+++ b/example/request_name.dart
@@ -1,7 +1,10 @@
 import 'package:dbus/dbus.dart';
 
 Future<void> acquireName(
-    DBusClient client, String name, Set<DBusRequestNameFlag> flags) async {
+  DBusClient client,
+  String name,
+  Set<DBusRequestNameFlag> flags,
+) async {
   var result = await client.requestName(name, flags: flags);
   switch (result) {
     case DBusRequestNameReply.primaryOwner:
@@ -24,13 +27,15 @@ void main() async {
   client.nameAcquired.listen((name) => print('Acquired name $name'));
   client.nameLost.listen((name) => print('Lost name $name'));
   await acquireName(client, 'com.canonical.DBusDart1', {});
-  await acquireName(client, 'com.canonical.DBusDart2',
-      {DBusRequestNameFlag.allowReplacement});
-  await acquireName(
-      client, 'com.canonical.DBusDart3', {DBusRequestNameFlag.replaceExisting});
+  await acquireName(client, 'com.canonical.DBusDart2', {
+    DBusRequestNameFlag.allowReplacement,
+  });
+  await acquireName(client, 'com.canonical.DBusDart3', {
+    DBusRequestNameFlag.replaceExisting,
+  });
   await acquireName(client, 'com.canonical.DBusDart4', {
     DBusRequestNameFlag.allowReplacement,
-    DBusRequestNameFlag.replaceExisting
+    DBusRequestNameFlag.replaceExisting,
   });
 
   print('Currently own names: ${client.ownedNames}');

--- a/example/server.dart
+++ b/example/server.dart
@@ -4,7 +4,8 @@ import 'package:dbus/dbus.dart';
 
 void main() async {
   var server = DBusServer();
-  var address =
-      await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+  var address = await server.listenAddress(
+    DBusAddress.unix(dir: Directory.systemTemp),
+  );
   print('Listening on $address');
 }

--- a/example/signals.dart
+++ b/example/signals.dart
@@ -11,7 +11,7 @@ class TestObject extends DBusObject {
       DBusIntrospectInterface(
         'com.canonical.DBusDart',
         signals: [DBusIntrospectSignal('Ping')],
-      )
+      ),
     ];
   }
 }
@@ -30,7 +30,10 @@ void main(List<String> args) async {
       path: DBusObjectPath('/com/canonical/DBusDart'),
     );
     var signals = DBusRemoteObjectSignalStream(
-        object: object, interface: 'com.canonical.DBusDart', name: 'Ping');
+      object: object,
+      interface: 'com.canonical.DBusDart',
+      name: 'Ping',
+    );
     await for (var signal in signals) {
       var count = signal.values[0].asUint64();
       print('Ping $count!');

--- a/lib/src/dbus_address.dart
+++ b/lib/src/dbus_address.dart
@@ -26,7 +26,8 @@ class DBusAddress {
     var index = address.indexOf(':');
     if (index < 0) {
       throw FormatException(
-          'Unable to determine transport of D-Bus address: $address');
+        'Unable to determine transport of D-Bus address: $address',
+      );
     }
 
     var transport = address.substring(0, index);
@@ -38,12 +39,13 @@ class DBusAddress {
   DBusAddress.withTransport(this.transport, this.properties);
 
   /// Creates a new D-Bus address connecting to a Unix socket.
-  factory DBusAddress.unix(
-      {String? path,
-      Directory? dir,
-      Directory? tmpdir,
-      String? abstract,
-      bool runtime = false}) {
+  factory DBusAddress.unix({
+    String? path,
+    Directory? dir,
+    Directory? tmpdir,
+    String? abstract,
+    bool runtime = false,
+  }) {
     var properties = <String, String>{};
     if (path != null) {
       properties['path'] = path;
@@ -64,8 +66,12 @@ class DBusAddress {
   }
 
   /// Creates a new D-Bus address connecting to a TCP socket.
-  factory DBusAddress.tcp(String host,
-      {String? bind, int? port, DBusAddressTcpFamily? family}) {
+  factory DBusAddress.tcp(
+    String host, {
+    String? bind,
+    int? port,
+    DBusAddressTcpFamily? family,
+  }) {
     var properties = <String, String>{'host': host};
     if (bind != null) {
       properties['bind'] = bind;
@@ -76,7 +82,7 @@ class DBusAddress {
     if (family != null) {
       properties['family'] = {
         DBusAddressTcpFamily.ipv4: 'ipv4',
-        DBusAddressTcpFamily.ipv6: 'ipv6'
+        DBusAddressTcpFamily.ipv6: 'ipv6',
       }[family]!;
     }
     return DBusAddress.withTransport('tcp', properties);
@@ -101,7 +107,8 @@ class DBusAddress {
         value = _decodeValue(property.substring(index + 1));
       } on FormatException {
         throw FormatException(
-            'Invalid value in D-Bus address property: $property');
+          'Invalid value in D-Bus address property: $property',
+        );
       }
 
       if (properties.containsKey(key)) {

--- a/lib/src/dbus_auth_client.dart
+++ b/lib/src/dbus_auth_client.dart
@@ -13,7 +13,7 @@ class DBusAuthClient {
   var _isAuthenticated = false;
   final bool _requestUnixFd;
   var _unixFdSupported = false;
-  DBusUUID? _uuid;
+  late DBusUUID _uuid;
   String? _errorMessage;
   final String? _uid;
 
@@ -27,7 +27,7 @@ class DBusAuthClient {
   bool get isAuthenticated => _isAuthenticated;
 
   /// The UUID of the connection. Only available if successfully authenticated.
-  DBusUUID get uuid => _uuid!;
+  DBusUUID get uuid => _uuid;
 
   /// True if Unix file descriptor passing is supported.
   bool get unixFdSupported => _unixFdSupported;
@@ -130,7 +130,7 @@ class DBusAuthClient {
   void _authenticateExternal() {
     String authId;
     if (_uid != null) {
-      authId = _uid!;
+      authId = _uid;
     } else if (Platform.isLinux) {
       authId = getuid().toString();
     } else if (Platform.isWindows) {

--- a/lib/src/dbus_auth_client.dart
+++ b/lib/src/dbus_auth_client.dart
@@ -37,8 +37,8 @@ class DBusAuthClient {
 
   /// Creates a new authentication client.
   DBusAuthClient({bool requestUnixFd = true, String? uid})
-      : _requestUnixFd = requestUnixFd,
-        _uid = uid {
+    : _requestUnixFd = requestUnixFd,
+      _uid = uid {
     // On start, end an empty byte, as this is required if sending the credentials as a socket control message.
     // We rely on the server using SO_PEERCRED to check out credentials.
     // Then request the supported mechanisms.

--- a/lib/src/dbus_auth_server.dart
+++ b/lib/src/dbus_auth_server.dart
@@ -25,7 +25,7 @@ class DBusAuthServer {
 
   /// Creates a new authentication server.
   DBusAuthServer(this.uuid, {bool unixFdSupported = false})
-      : _unixFdSupported = unixFdSupported;
+    : _unixFdSupported = unixFdSupported;
 
   /// Process a request [message] received from the client.
   void processRequest(String message) {

--- a/lib/src/dbus_client.dart
+++ b/lib/src/dbus_client.dart
@@ -56,13 +56,14 @@ class DBusProcessCredentials {
   /// Non-standard credentials.
   final Map<String, DBusValue> otherCredentials;
 
-  const DBusProcessCredentials(
-      {this.unixUserId,
-      this.unixGroupIds,
-      this.processId,
-      this.windowsSid,
-      this.linuxSecurityLabel,
-      this.otherCredentials = const {}});
+  const DBusProcessCredentials({
+    this.unixUserId,
+    this.unixGroupIds,
+    this.processId,
+    this.windowsSid,
+    this.linuxSecurityLabel,
+    this.otherCredentials = const {},
+  });
 
   @override
   String toString() {
@@ -72,8 +73,9 @@ class DBusProcessCredentials {
       'processId': processId?.toString(),
       'windowsSid': windowsSid?.toString(),
       'linuxSecurityLabel': linuxSecurityLabel?.toString(),
-      'otherCredentials':
-          otherCredentials.isNotEmpty ? otherCredentials.toString() : null
+      'otherCredentials': otherCredentials.isNotEmpty
+          ? otherCredentials.toString()
+          : null,
     };
     var parameterString = parameters.keys
         .where((key) => parameters[key] != null)
@@ -95,34 +97,41 @@ class DBusSignalStream extends Stream<DBusSignal> {
   /// If [signature] is provided this causes the stream to throw a
   /// [DBusSignalSignatureException] if a signal is received that does not
   /// match the provided signature.
-  DBusSignalStream(DBusClient client,
-      {String? sender,
-      String? interface,
-      String? name,
-      DBusObjectPath? path,
-      DBusObjectPath? pathNamespace,
-      DBusSignature? signature})
-      : _client = client,
-        _rule = DBusMatchRule(
-            type: DBusMessageType.signal,
-            sender: sender != null ? DBusBusName(sender) : null,
-            interface: interface != null ? DBusInterfaceName(interface) : null,
-            member: name != null ? DBusMemberName(name) : null,
-            path: path,
-            pathNamespace: pathNamespace),
-        _signature = signature {
+  DBusSignalStream(
+    DBusClient client, {
+    String? sender,
+    String? interface,
+    String? name,
+    DBusObjectPath? path,
+    DBusObjectPath? pathNamespace,
+    DBusSignature? signature,
+  }) : _client = client,
+       _rule = DBusMatchRule(
+         type: DBusMessageType.signal,
+         sender: sender != null ? DBusBusName(sender) : null,
+         interface: interface != null ? DBusInterfaceName(interface) : null,
+         member: name != null ? DBusMemberName(name) : null,
+         path: path,
+         pathNamespace: pathNamespace,
+       ),
+       _signature = signature {
     _controller.onListen = _onListen;
     _controller.onCancel = _onCancel;
   }
 
   @override
   StreamSubscription<DBusSignal> listen(
-      void Function(DBusSignal signal)? onData,
-      {Function? onError,
-      void Function()? onDone,
-      bool? cancelOnError}) {
-    return _controller.stream.listen(onData,
-        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+    void Function(DBusSignal signal)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
+    return _controller.stream.listen(
+      onData,
+      onError: onError,
+      onDone: onDone,
+      cancelOnError: cancelOnError,
+    );
   }
 
   void _onListen() {
@@ -245,20 +254,22 @@ class DBusClient {
   /// If [messageBus] is false, then the server is not running a message bus and
   /// no addresses or client to client communication is supported.
   /// If [authClient] is provided, it will be used instead of creating a new one.
-  DBusClient(DBusAddress address,
-      {this.introspectable = true,
-      bool messageBus = true,
-      DBusAuthClient? authClient})
-      : _address = address,
-        _messageBus = messageBus,
-        _authClient = authClient ?? DBusAuthClient();
+  DBusClient(
+    DBusAddress address, {
+    this.introspectable = true,
+    bool messageBus = true,
+    DBusAuthClient? authClient,
+  }) : _address = address,
+       _messageBus = messageBus,
+       _authClient = authClient ?? DBusAuthClient();
 
   /// Creates a new DBus client to communicate with the system bus.
   factory DBusClient.system({bool introspectable = true}) {
     var address = Platform.environment['DBUS_SYSTEM_BUS_ADDRESS'];
     return DBusClient(
-        DBusAddress(address ??= 'unix:path=/var/run/dbus/system_bus_socket'),
-        introspectable: introspectable);
+      DBusAddress(address ??= 'unix:path=/var/run/dbus/system_bus_socket'),
+      introspectable: introspectable,
+    );
   }
 
   /// Creates a new DBus client to communicate with the session bus.
@@ -298,40 +309,47 @@ class DBusClient {
   Iterable<String> get ownedNames => _ownedNames.map((name) => name.value);
 
   /// Stream of names as they are acquired by this client.
-  Stream<String> get nameAcquired => DBusSignalStream(this,
-          sender: 'org.freedesktop.DBus',
-          interface: 'org.freedesktop.DBus',
-          name: 'NameAcquired',
-          signature: DBusSignature('s'))
-      .map((signal) => signal.values[0].asString());
+  Stream<String> get nameAcquired => DBusSignalStream(
+    this,
+    sender: 'org.freedesktop.DBus',
+    interface: 'org.freedesktop.DBus',
+    name: 'NameAcquired',
+    signature: DBusSignature('s'),
+  ).map((signal) => signal.values[0].asString());
 
   /// Stream of names as this client loses them.
-  Stream<String> get nameLost => DBusSignalStream(this,
-          sender: 'org.freedesktop.DBus',
-          interface: 'org.freedesktop.DBus',
-          name: 'NameLost',
-          signature: DBusSignature('s'))
-      .map((signal) => signal.values[0].asString());
+  Stream<String> get nameLost => DBusSignalStream(
+    this,
+    sender: 'org.freedesktop.DBus',
+    interface: 'org.freedesktop.DBus',
+    name: 'NameLost',
+    signature: DBusSignature('s'),
+  ).map((signal) => signal.values[0].asString());
 
   /// Stream of name change events.
   Stream<DBusNameOwnerChangedEvent> get nameOwnerChanged =>
-      DBusSignalStream(this,
-              sender: 'org.freedesktop.DBus',
-              interface: 'org.freedesktop.DBus',
-              name: 'NameOwnerChanged',
-              signature: DBusSignature('sss'))
-          .map((signal) {
+      DBusSignalStream(
+        this,
+        sender: 'org.freedesktop.DBus',
+        interface: 'org.freedesktop.DBus',
+        name: 'NameOwnerChanged',
+        signature: DBusSignature('sss'),
+      ).map((signal) {
         var name = signal.values[0].asString();
         var oldOwner = signal.values[1].asString();
         var newOwner = signal.values[2].asString();
-        return DBusNameOwnerChangedEvent(name,
-            oldOwner: oldOwner != '' ? oldOwner : null,
-            newOwner: newOwner != '' ? newOwner : null);
+        return DBusNameOwnerChangedEvent(
+          name,
+          oldOwner: oldOwner != '' ? oldOwner : null,
+          newOwner: newOwner != '' ? newOwner : null,
+        );
       });
 
   /// Requests usage of [name] as a D-Bus object name.
-  Future<DBusRequestNameReply> requestName(String name,
-      {Set<DBusRequestNameFlag> flags = const {}}) async {
+  Future<DBusRequestNameReply> requestName(
+    String name, {
+    Set<DBusRequestNameFlag> flags = const {},
+  }) async {
     var flagsValue = 0;
     for (var flag in flags) {
       switch (flag) {
@@ -347,12 +365,13 @@ class DBusClient {
       }
     }
     var result = await callMethod(
-        destination: 'org.freedesktop.DBus',
-        path: DBusObjectPath('/org/freedesktop/DBus'),
-        interface: 'org.freedesktop.DBus',
-        name: 'RequestName',
-        values: [DBusString(name), DBusUint32(flagsValue)],
-        replySignature: DBusSignature('u'));
+      destination: 'org.freedesktop.DBus',
+      path: DBusObjectPath('/org/freedesktop/DBus'),
+      interface: 'org.freedesktop.DBus',
+      name: 'RequestName',
+      values: [DBusString(name), DBusUint32(flagsValue)],
+      replySignature: DBusSignature('u'),
+    );
     var returnCode = result.returnValues[0].asUint32();
     switch (returnCode) {
       case 1:
@@ -372,12 +391,13 @@ class DBusClient {
   /// Releases the D-Bus object name previously acquired using requestName().
   Future<DBusReleaseNameReply> releaseName(String name) async {
     var result = await callMethod(
-        destination: 'org.freedesktop.DBus',
-        path: DBusObjectPath('/org/freedesktop/DBus'),
-        interface: 'org.freedesktop.DBus',
-        name: 'ReleaseName',
-        values: [DBusString(name)],
-        replySignature: DBusSignature('u'));
+      destination: 'org.freedesktop.DBus',
+      path: DBusObjectPath('/org/freedesktop/DBus'),
+      interface: 'org.freedesktop.DBus',
+      name: 'ReleaseName',
+      values: [DBusString(name)],
+      replySignature: DBusSignature('u'),
+    );
     var returnCode = result.returnValues[0].asUint32();
     switch (returnCode) {
       case 1:
@@ -395,46 +415,50 @@ class DBusClient {
   /// Lists the unique bus names of the clients queued to own the well-known bus [name].
   Future<List<String>> listQueuedOwners(String name) async {
     var result = await callMethod(
-        destination: 'org.freedesktop.DBus',
-        path: DBusObjectPath('/org/freedesktop/DBus'),
-        interface: 'org.freedesktop.DBus',
-        name: 'ListQueuedOwners',
-        values: [DBusString(name)],
-        replySignature: DBusSignature('as'));
+      destination: 'org.freedesktop.DBus',
+      path: DBusObjectPath('/org/freedesktop/DBus'),
+      interface: 'org.freedesktop.DBus',
+      name: 'ListQueuedOwners',
+      values: [DBusString(name)],
+      replySignature: DBusSignature('as'),
+    );
     return result.returnValues[0].asStringArray().toList();
   }
 
   /// Lists the registered names on the bus.
   Future<List<String>> listNames() async {
     var result = await callMethod(
-        destination: 'org.freedesktop.DBus',
-        path: DBusObjectPath('/org/freedesktop/DBus'),
-        interface: 'org.freedesktop.DBus',
-        name: 'ListNames',
-        replySignature: DBusSignature('as'));
+      destination: 'org.freedesktop.DBus',
+      path: DBusObjectPath('/org/freedesktop/DBus'),
+      interface: 'org.freedesktop.DBus',
+      name: 'ListNames',
+      replySignature: DBusSignature('as'),
+    );
     return result.returnValues[0].asStringArray().toList();
   }
 
   /// Returns a list of names that activate services.
   Future<List<String>> listActivatableNames() async {
     var result = await callMethod(
-        destination: 'org.freedesktop.DBus',
-        path: DBusObjectPath('/org/freedesktop/DBus'),
-        interface: 'org.freedesktop.DBus',
-        name: 'ListActivatableNames',
-        replySignature: DBusSignature('as'));
+      destination: 'org.freedesktop.DBus',
+      path: DBusObjectPath('/org/freedesktop/DBus'),
+      interface: 'org.freedesktop.DBus',
+      name: 'ListActivatableNames',
+      replySignature: DBusSignature('as'),
+    );
     return result.returnValues[0].asStringArray().toList();
   }
 
   /// Starts the service with [name].
   Future<DBusStartServiceByNameReply> startServiceByName(String name) async {
     var result = await callMethod(
-        destination: 'org.freedesktop.DBus',
-        path: DBusObjectPath('/org/freedesktop/DBus'),
-        interface: 'org.freedesktop.DBus',
-        name: 'StartServiceByName',
-        values: [DBusString(name), DBusUint32(0)],
-        replySignature: DBusSignature('u'));
+      destination: 'org.freedesktop.DBus',
+      path: DBusObjectPath('/org/freedesktop/DBus'),
+      interface: 'org.freedesktop.DBus',
+      name: 'StartServiceByName',
+      values: [DBusString(name), DBusUint32(0)],
+      replySignature: DBusSignature('u'),
+    );
     var returnCode = result.returnValues[0].asUint32();
     switch (returnCode) {
       case 1:
@@ -449,12 +473,13 @@ class DBusClient {
   /// Returns true if the [name] is currently registered on the bus.
   Future<bool> nameHasOwner(String name) async {
     var result = await callMethod(
-        destination: 'org.freedesktop.DBus',
-        path: DBusObjectPath('/org/freedesktop/DBus'),
-        interface: 'org.freedesktop.DBus',
-        name: 'NameHasOwner',
-        values: [DBusString(name)],
-        replySignature: DBusSignature('b'));
+      destination: 'org.freedesktop.DBus',
+      path: DBusObjectPath('/org/freedesktop/DBus'),
+      interface: 'org.freedesktop.DBus',
+      name: 'NameHasOwner',
+      values: [DBusString(name)],
+      replySignature: DBusSignature('b'),
+    );
     return result.returnValues[0].asBoolean();
   }
 
@@ -463,12 +488,13 @@ class DBusClient {
     DBusMethodSuccessResponse result;
     try {
       result = await callMethod(
-          destination: 'org.freedesktop.DBus',
-          path: DBusObjectPath('/org/freedesktop/DBus'),
-          interface: 'org.freedesktop.DBus',
-          name: 'GetNameOwner',
-          values: [DBusString(name)],
-          replySignature: DBusSignature('s'));
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/org/freedesktop/DBus'),
+        interface: 'org.freedesktop.DBus',
+        name: 'GetNameOwner',
+        values: [DBusString(name)],
+        replySignature: DBusSignature('s'),
+      );
     } on DBusMethodResponseException catch (e) {
       if (e.response.errorName == 'org.freedesktop.DBus.Error.NameHasNoOwner') {
         return null;
@@ -481,36 +507,39 @@ class DBusClient {
   /// Returns the Unix user ID of the process running the client that owns [name].
   Future<int> getConnectionUnixUser(String name) async {
     var result = await callMethod(
-        destination: 'org.freedesktop.DBus',
-        path: DBusObjectPath('/org/freedesktop/DBus'),
-        interface: 'org.freedesktop.DBus',
-        name: 'GetConnectionUnixUser',
-        values: [DBusString(name)],
-        replySignature: DBusSignature('u'));
+      destination: 'org.freedesktop.DBus',
+      path: DBusObjectPath('/org/freedesktop/DBus'),
+      interface: 'org.freedesktop.DBus',
+      name: 'GetConnectionUnixUser',
+      values: [DBusString(name)],
+      replySignature: DBusSignature('u'),
+    );
     return result.returnValues[0].asUint32();
   }
 
   /// Returns the Unix process ID of the process running the client that owns [name].
   Future<int> getConnectionUnixProcessId(String name) async {
     var result = await callMethod(
-        destination: 'org.freedesktop.DBus',
-        path: DBusObjectPath('/org/freedesktop/DBus'),
-        interface: 'org.freedesktop.DBus',
-        name: 'GetConnectionUnixProcessID',
-        values: [DBusString(name)],
-        replySignature: DBusSignature('u'));
+      destination: 'org.freedesktop.DBus',
+      path: DBusObjectPath('/org/freedesktop/DBus'),
+      interface: 'org.freedesktop.DBus',
+      name: 'GetConnectionUnixProcessID',
+      values: [DBusString(name)],
+      replySignature: DBusSignature('u'),
+    );
     return result.returnValues[0].asUint32();
   }
 
   /// Returns credentials for the process running the client that owns [name].
   Future<DBusProcessCredentials> getConnectionCredentials(String name) async {
     var result = await callMethod(
-        destination: 'org.freedesktop.DBus',
-        path: DBusObjectPath('/org/freedesktop/DBus'),
-        interface: 'org.freedesktop.DBus',
-        name: 'GetConnectionCredentials',
-        values: [DBusString(name)],
-        replySignature: DBusSignature('a{sv}'));
+      destination: 'org.freedesktop.DBus',
+      path: DBusObjectPath('/org/freedesktop/DBus'),
+      interface: 'org.freedesktop.DBus',
+      name: 'GetConnectionCredentials',
+      values: [DBusString(name)],
+      replySignature: DBusSignature('a{sv}'),
+    );
     var credentials = result.returnValues[0].asStringVariantDict();
     int? unixUserId;
     List<int>? unixGroupIds;
@@ -556,22 +585,24 @@ class DBusClient {
       }
     });
     return DBusProcessCredentials(
-        unixUserId: unixUserId,
-        unixGroupIds: unixGroupIds,
-        processId: processId,
-        windowsSid: windowsSid,
-        linuxSecurityLabel: linuxSecurityLabel,
-        otherCredentials: otherCredentials);
+      unixUserId: unixUserId,
+      unixGroupIds: unixGroupIds,
+      processId: processId,
+      windowsSid: windowsSid,
+      linuxSecurityLabel: linuxSecurityLabel,
+      otherCredentials: otherCredentials,
+    );
   }
 
   /// Gets the unique ID of the bus.
   Future<String> getId() async {
     var result = await callMethod(
-        destination: 'org.freedesktop.DBus',
-        path: DBusObjectPath('/org/freedesktop/DBus'),
-        interface: 'org.freedesktop.DBus',
-        name: 'GetId',
-        replySignature: DBusSignature('s'));
+      destination: 'org.freedesktop.DBus',
+      path: DBusObjectPath('/org/freedesktop/DBus'),
+      interface: 'org.freedesktop.DBus',
+      name: 'GetId',
+      replySignature: DBusSignature('s'),
+    );
     return result.returnValues[0].asString();
   }
 
@@ -579,23 +610,26 @@ class DBusClient {
   /// If [destination] is not set, pings the D-Bus server.
   Future<void> ping([String destination = 'org.freedesktop.DBus']) async {
     await callMethod(
-        destination: destination,
-        path: DBusObjectPath.root,
-        interface: 'org.freedesktop.DBus.Peer',
-        name: 'Ping',
-        replySignature: DBusSignature(''));
+      destination: destination,
+      path: DBusObjectPath.root,
+      interface: 'org.freedesktop.DBus.Peer',
+      name: 'Ping',
+      replySignature: DBusSignature(''),
+    );
   }
 
   /// Gets the machine ID of the client at the given [destination].
   /// If [destination] is not set, gets the machine the D-Bus server is running on.
-  Future<String> getMachineId(
-      [String destination = 'org.freedesktop.DBus']) async {
+  Future<String> getMachineId([
+    String destination = 'org.freedesktop.DBus',
+  ]) async {
     var result = await callMethod(
-        destination: destination,
-        path: DBusObjectPath.root,
-        interface: 'org.freedesktop.DBus.Peer',
-        name: 'GetMachineId',
-        replySignature: DBusSignature('s'));
+      destination: destination,
+      path: DBusObjectPath.root,
+      interface: 'org.freedesktop.DBus.Peer',
+      name: 'GetMachineId',
+      replySignature: DBusSignature('s'),
+    );
     return result.returnValues[0].asString();
   }
 
@@ -611,27 +645,29 @@ class DBusClient {
   /// Throws [DBusUnknownInterfaceException] if [interface] is not provided by this object.
   /// Throws [DBusUnknownMethodException] if the method with [name] is not available.
   /// Throws [DBusInvalidArgsException] if [values] aren't correct.
-  Future<DBusMethodSuccessResponse> callMethod(
-      {String? destination,
-      required DBusObjectPath path,
-      String? interface,
-      required String name,
-      Iterable<DBusValue> values = const [],
-      DBusSignature? replySignature,
-      bool noReplyExpected = false,
-      bool noAutoStart = false,
-      bool allowInteractiveAuthorization = false}) async {
+  Future<DBusMethodSuccessResponse> callMethod({
+    String? destination,
+    required DBusObjectPath path,
+    String? interface,
+    required String name,
+    Iterable<DBusValue> values = const [],
+    DBusSignature? replySignature,
+    bool noReplyExpected = false,
+    bool noAutoStart = false,
+    bool allowInteractiveAuthorization = false,
+  }) async {
     await _connect();
     return await _callMethod(
-        destination: destination != null ? DBusBusName(destination) : null,
-        path: path,
-        interface: interface != null ? DBusInterfaceName(interface) : null,
-        name: DBusMemberName(name),
-        values: values,
-        replySignature: replySignature,
-        noReplyExpected: noReplyExpected,
-        noAutoStart: noAutoStart,
-        allowInteractiveAuthorization: allowInteractiveAuthorization);
+      destination: destination != null ? DBusBusName(destination) : null,
+      path: path,
+      interface: interface != null ? DBusInterfaceName(interface) : null,
+      name: DBusMemberName(name),
+      values: values,
+      replySignature: replySignature,
+      noReplyExpected: noReplyExpected,
+      noAutoStart: noAutoStart,
+      allowInteractiveAuthorization: allowInteractiveAuthorization,
+    );
   }
 
   /// Find the unique name for a D-Bus client.
@@ -649,15 +685,21 @@ class DBusClient {
   }
 
   /// Emits a signal from a D-Bus object.
-  Future<void> emitSignal(
-      {String? destination,
-      required DBusObjectPath path,
-      required String interface,
-      required String name,
-      Iterable<DBusValue> values = const []}) async {
+  Future<void> emitSignal({
+    String? destination,
+    required DBusObjectPath path,
+    required String interface,
+    required String name,
+    Iterable<DBusValue> values = const [],
+  }) async {
     await _connect();
-    _sendSignal(destination != null ? DBusBusName(destination) : null, path,
-        DBusInterfaceName(interface), DBusMemberName(name), values);
+    _sendSignal(
+      destination != null ? DBusBusName(destination) : null,
+      path,
+      DBusInterfaceName(interface),
+      DBusMemberName(name),
+      values,
+    );
   }
 
   /// Searches for an object manager in [node] or any of its parents.
@@ -692,10 +734,14 @@ class DBusClient {
     // If has an object manager as a parent, emit a signal to indicate this was added.
     var objectManager = _findObjectManager(node.parent);
     if (objectManager != null) {
-      var interfacesAndProperties = expandObjectInterfaceAndProperties(object,
-          introspectable: introspectable);
+      var interfacesAndProperties = expandObjectInterfaceAndProperties(
+        object,
+        introspectable: introspectable,
+      );
       await objectManager.emitInterfacesAdded(
-          object.path, interfacesAndProperties);
+        object.path,
+        interfacesAndProperties,
+      );
     }
   }
 
@@ -717,10 +763,14 @@ class DBusClient {
     // If has an object manager as a parent, emit a signal to indicate this was removed.
     var objectManager = _findObjectManager(node.parent);
     if (objectManager != null) {
-      var interfacesAndProperties = expandObjectInterfaceAndProperties(object,
-          introspectable: introspectable);
+      var interfacesAndProperties = expandObjectInterfaceAndProperties(
+        object,
+        introspectable: introspectable,
+      );
       await objectManager.emitInterfacesRemoved(
-          object.path, interfacesAndProperties.keys);
+        object.path,
+        interfacesAndProperties.keys,
+      );
     }
   }
 
@@ -802,8 +852,9 @@ class DBusClient {
     _connectCompleter = Completer();
 
     await _openSocket();
-    _authClient.requests
-        .listen((message) => _socket?.write(utf8.encode('$message\r\n')));
+    _authClient.requests.listen(
+      (message) => _socket?.write(utf8.encode('$message\r\n')),
+    );
     await _authClient.done;
     _authComplete = true;
     if (!_authClient.isAuthenticated) {
@@ -820,11 +871,12 @@ class DBusClient {
     // false as the _connect call hasn't yet completed and would otherwise have
     // been called again.
     var result = await _callMethod(
-        destination: DBusBusName('org.freedesktop.DBus'),
-        path: DBusObjectPath('/org/freedesktop/DBus'),
-        interface: DBusInterfaceName('org.freedesktop.DBus'),
-        name: DBusMemberName('Hello'),
-        replySignature: DBusSignature('s'));
+      destination: DBusBusName('org.freedesktop.DBus'),
+      path: DBusObjectPath('/org/freedesktop/DBus'),
+      interface: DBusInterfaceName('org.freedesktop.DBus'),
+      name: DBusMemberName('Hello'),
+      replySignature: DBusSignature('s'),
+    );
     _uniqueName = DBusBusName(result.returnValues[0].asString());
 
     // Notify anyone else awaiting connection.
@@ -857,12 +909,13 @@ class DBusClient {
     if (count == null) {
       _matchRules[rule] = 1;
       await callMethod(
-          destination: 'org.freedesktop.DBus',
-          path: DBusObjectPath('/org/freedesktop/DBus'),
-          interface: 'org.freedesktop.DBus',
-          name: 'AddMatch',
-          values: [DBusString(rule)],
-          replySignature: DBusSignature(''));
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/org/freedesktop/DBus'),
+        interface: 'org.freedesktop.DBus',
+        name: 'AddMatch',
+        values: [DBusString(rule)],
+        replySignature: DBusSignature(''),
+      );
     } else {
       _matchRules[rule] = count + 1;
     }
@@ -879,12 +932,13 @@ class DBusClient {
       _matchRules.remove(rule);
       if (!_socketClosed) {
         await callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/org/freedesktop/DBus'),
-            interface: 'org.freedesktop.DBus',
-            name: 'RemoveMatch',
-            values: [DBusString(rule)],
-            replySignature: DBusSignature(''));
+          destination: 'org.freedesktop.DBus',
+          path: DBusObjectPath('/org/freedesktop/DBus'),
+          interface: 'org.freedesktop.DBus',
+          name: 'RemoveMatch',
+          values: [DBusString(rule)],
+          replySignature: DBusSignature(''),
+        );
       }
     } else {
       _matchRules[rule] = count - 1;
@@ -972,15 +1026,16 @@ class DBusClient {
     var object = node?.object;
 
     var methodCall = DBusMethodCall(
-        sender: message.sender?.value ?? '',
-        interface: message.interface?.value,
-        name: message.member?.value ?? '',
-        values: message.values,
-        noReplyExpected:
-            message.flags.contains(DBusMessageFlag.noReplyExpected),
-        noAutoStart: message.flags.contains(DBusMessageFlag.noAutoStart),
-        allowInteractiveAuthorization: message.flags
-            .contains(DBusMessageFlag.allowInteractiveAuthorization));
+      sender: message.sender?.value ?? '',
+      interface: message.interface?.value,
+      name: message.member?.value ?? '',
+      values: message.values,
+      noReplyExpected: message.flags.contains(DBusMessageFlag.noReplyExpected),
+      noAutoStart: message.flags.contains(DBusMessageFlag.noAutoStart),
+      allowInteractiveAuthorization: message.flags.contains(
+        DBusMessageFlag.allowInteractiveAuthorization,
+      ),
+    );
 
     DBusMethodResponse response;
     if (message.member == null) {
@@ -996,8 +1051,11 @@ class DBusClient {
       response = await handlePropertiesMethodCall(object, methodCall);
     } else if (object.isObjectManager &&
         message.interface?.value == 'org.freedesktop.DBus.ObjectManager') {
-      response = handleObjectManagerMethodCall(_objectTree, methodCall,
-          introspectable: introspectable);
+      response = handleObjectManagerMethodCall(
+        _objectTree,
+        methodCall,
+        introspectable: introspectable,
+      );
     } else {
       response = await object.handleMethodCall(methodCall);
     }
@@ -1012,7 +1070,11 @@ class DBusClient {
 
     if (response is DBusMethodErrorResponse) {
       _sendError(
-          message.serial, message.sender, response.errorName, response.values);
+        message.serial,
+        message.sender,
+        response.errorName,
+        response.values,
+      );
     } else if (response is DBusMethodSuccessResponse) {
       _sendReturn(message.serial, message.sender, response.values);
     }
@@ -1034,7 +1096,9 @@ class DBusClient {
     DBusMethodResponse response;
     if (message.type == DBusMessageType.error) {
       response = DBusMethodErrorResponse(
-          message.errorName?.value ?? '(missing error name)', message.values);
+        message.errorName?.value ?? '(missing error name)',
+        message.values,
+      );
     } else {
       response = DBusMethodSuccessResponse(message.values);
     }
@@ -1058,23 +1122,29 @@ class DBusClient {
       }
 
       if (!stream._rule.match(
-          type: DBusMessageType.signal,
-          sender: sender,
-          interface: message.interface,
-          member: message.member,
-          path: message.path)) {
+        type: DBusMessageType.signal,
+        sender: sender,
+        interface: message.interface,
+        member: message.member,
+        path: message.path,
+      )) {
         continue;
       }
 
       var signal = DBusSignal(
-          sender: message.sender?.value,
-          path: message.path ?? DBusObjectPath.root,
-          interface: message.interface?.value ?? '',
-          name: message.member?.value ?? '',
-          values: message.values);
+        sender: message.sender?.value,
+        path: message.path ?? DBusObjectPath.root,
+        interface: message.interface?.value ?? '',
+        name: message.member?.value ?? '',
+        values: message.values,
+      );
       if (stream._signature != null && message.signature != stream._signature) {
-        stream._controller.addError(DBusSignalSignatureException(
-            '${message.interface?.value}.${message.member?.value}', signal));
+        stream._controller.addError(
+          DBusSignalSignatureException(
+            '${message.interface?.value}.${message.member?.value}',
+            signal,
+          ),
+        );
       } else {
         stream._controller.add(signal);
       }
@@ -1082,16 +1152,17 @@ class DBusClient {
   }
 
   /// Invokes a method on a D-Bus object.
-  Future<DBusMethodSuccessResponse> _callMethod(
-      {DBusBusName? destination,
-      required DBusObjectPath path,
-      DBusInterfaceName? interface,
-      required DBusMemberName name,
-      Iterable<DBusValue> values = const {},
-      DBusSignature? replySignature,
-      bool noReplyExpected = false,
-      bool noAutoStart = false,
-      bool allowInteractiveAuthorization = false}) async {
+  Future<DBusMethodSuccessResponse> _callMethod({
+    DBusBusName? destination,
+    required DBusObjectPath path,
+    DBusInterfaceName? interface,
+    required DBusMemberName name,
+    Iterable<DBusValue> values = const {},
+    DBusSignature? replySignature,
+    bool noReplyExpected = false,
+    bool noAutoStart = false,
+    bool allowInteractiveAuthorization = false,
+  }) async {
     _lastSerial++;
     var serial = _lastSerial;
     Future<DBusMethodResponse> response;
@@ -1113,22 +1184,25 @@ class DBusClient {
     if (allowInteractiveAuthorization) {
       flags.add(DBusMessageFlag.allowInteractiveAuthorization);
     }
-    var message = DBusMessage(DBusMessageType.methodCall,
-        serial: _lastSerial,
-        destination: destination,
-        path: path,
-        interface: interface,
-        member: name,
-        values: values.toList(),
-        flags: flags);
+    var message = DBusMessage(
+      DBusMessageType.methodCall,
+      serial: _lastSerial,
+      destination: destination,
+      path: path,
+      interface: interface,
+      member: name,
+      values: values.toList(),
+      flags: flags,
+    );
     _sendMessage(message);
 
     var r = await response;
     if (r is DBusMethodSuccessResponse) {
       /// Check returned values match expected signature.
       if (replySignature != null && r.signature != replySignature) {
-        var fullName =
-            interface != null ? '${interface.value}.${name.value}' : name.value;
+        var fullName = interface != null
+            ? '${interface.value}.${name.value}'
+            : name.value;
         throw DBusReplySignatureException(fullName, r);
       }
 
@@ -1177,44 +1251,58 @@ class DBusClient {
 
   /// Sends a method return to the D-Bus server.
   void _sendReturn(
-      int serial, DBusBusName? destination, Iterable<DBusValue> values) {
+    int serial,
+    DBusBusName? destination,
+    Iterable<DBusValue> values,
+  ) {
     _lastSerial++;
-    var message = DBusMessage(DBusMessageType.methodReturn,
-        serial: _lastSerial,
-        replySerial: serial,
-        destination: destination,
-        values: values.toList());
+    var message = DBusMessage(
+      DBusMessageType.methodReturn,
+      serial: _lastSerial,
+      replySerial: serial,
+      destination: destination,
+      values: values.toList(),
+    );
     _sendMessage(message);
   }
 
   /// Sends an error to the D-Bus server.
-  void _sendError(int serial, DBusBusName? destination, String errorName,
-      Iterable<DBusValue> values) {
+  void _sendError(
+    int serial,
+    DBusBusName? destination,
+    String errorName,
+    Iterable<DBusValue> values,
+  ) {
     _lastSerial++;
-    var message = DBusMessage(DBusMessageType.error,
-        serial: _lastSerial,
-        errorName: DBusErrorName(errorName),
-        replySerial: serial,
-        destination: destination,
-        values: values.toList());
+    var message = DBusMessage(
+      DBusMessageType.error,
+      serial: _lastSerial,
+      errorName: DBusErrorName(errorName),
+      replySerial: serial,
+      destination: destination,
+      values: values.toList(),
+    );
     _sendMessage(message);
   }
 
   /// Sends a signal to the D-Bus server.
   void _sendSignal(
-      DBusBusName? destination,
-      DBusObjectPath path,
-      DBusInterfaceName interface,
-      DBusMemberName name,
-      Iterable<DBusValue> values) {
+    DBusBusName? destination,
+    DBusObjectPath path,
+    DBusInterfaceName interface,
+    DBusMemberName name,
+    Iterable<DBusValue> values,
+  ) {
     _lastSerial++;
-    var message = DBusMessage(DBusMessageType.signal,
-        serial: _lastSerial,
-        destination: destination,
-        path: path,
-        interface: interface,
-        member: name,
-        values: values.toList());
+    var message = DBusMessage(
+      DBusMessageType.signal,
+      serial: _lastSerial,
+      destination: destination,
+      path: path,
+      interface: interface,
+      member: name,
+      values: values.toList(),
+    );
     _sendMessage(message);
   }
 
@@ -1234,8 +1322,9 @@ class DBusClient {
 
     var controlMessages = <SocketControlMessage>[];
     if (buffer.resourceHandles.isNotEmpty) {
-      controlMessages
-          .add(SocketControlMessage.fromHandles(buffer.resourceHandles));
+      controlMessages.add(
+        SocketControlMessage.fromHandles(buffer.resourceHandles),
+      );
     }
 
     _socket?.sendMessage(controlMessages, buffer.data);

--- a/lib/src/dbus_code_generator.dart
+++ b/lib/src/dbus_code_generator.dart
@@ -23,7 +23,7 @@ class DBusCodeGenerator {
   /// [className] is the name of the generated class, if not provided it will be inferred from [node].
   /// If provided [comment] is added to the top of the source.
   DBusCodeGenerator(this.node, {String? comment, String? className})
-      : _comment = comment {
+    : _comment = comment {
     var className_ = className ?? _nodeToClassName();
     if (className_ == null) {
       throw 'Unable to determine class name';
@@ -81,7 +81,7 @@ class DBusCodeGenerator {
       'emitSignal',
       'getAllProperties',
       'getProperty',
-      'setProperty'
+      'setProperty',
     ];
     var getMethodNames = <String, String>{};
     var setMethodNames = <String, String>{};
@@ -92,12 +92,20 @@ class DBusCodeGenerator {
     // Generate all the methods for this object.
     for (var interface in node.interfaces) {
       for (var property in interface.properties) {
-        methods.addAll(_generatePropertyImplementationMethods(
-            memberNames, getMethodNames, setMethodNames, interface, property));
+        methods.addAll(
+          _generatePropertyImplementationMethods(
+            memberNames,
+            getMethodNames,
+            setMethodNames,
+            interface,
+            property,
+          ),
+        );
       }
       for (var method in interface.methods) {
-        methods
-            .add(_generateMethodImplementation(memberNames, interface, method));
+        methods.add(
+          _generateMethodImplementation(memberNames, interface, method),
+        );
       }
       for (var signal in interface.signals) {
         methods.add(_generateSignalEmitMethod(memberNames, interface, signal));
@@ -153,11 +161,12 @@ class DBusCodeGenerator {
 
   // Generates a stub implementation of [property].
   List<String> _generatePropertyImplementationMethods(
-      List<String> memberNames,
-      Map<String, String> getMethodNames,
-      Map<String, String> setMethodNames,
-      DBusIntrospectInterface interface,
-      DBusIntrospectProperty property) {
+    List<String> memberNames,
+    Map<String, String> getMethodNames,
+    Map<String, String> setMethodNames,
+    DBusIntrospectInterface interface,
+    DBusIntrospectProperty property,
+  ) {
     var methods = <String>[];
 
     var type = getDartType(property.type);
@@ -195,8 +204,11 @@ class DBusCodeGenerator {
   }
 
   // Generates a stub implementation of [method].
-  String _generateMethodImplementation(List<String> memberNames,
-      DBusIntrospectInterface interface, DBusIntrospectMethod method) {
+  String _generateMethodImplementation(
+    List<String> memberNames,
+    DBusIntrospectInterface interface,
+    DBusIntrospectMethod method,
+  ) {
     var argValues = <String>[];
     var argsList = <String>[];
     var index = 0;
@@ -212,7 +224,9 @@ class DBusCodeGenerator {
     }
 
     var isNoReply = _getBooleanAnnotation(
-        method.annotations, 'org.freedesktop.DBus.Method.NoReply');
+      method.annotations,
+      'org.freedesktop.DBus.Method.NoReply',
+    );
     var returnType = isNoReply ? 'void' : 'DBusMethodResponse';
 
     var methodName = _getUniqueMethodName(memberNames, 'do${method.name}');
@@ -231,8 +245,11 @@ class DBusCodeGenerator {
   }
 
   // Generates a method to emit a signal.
-  String _generateSignalEmitMethod(List<String> memberNames,
-      DBusIntrospectInterface interface, DBusIntrospectSignal signal) {
+  String _generateSignalEmitMethod(
+    List<String> memberNames,
+    DBusIntrospectInterface interface,
+    DBusIntrospectSignal signal,
+  ) {
     var argNames = [
       // Dart keywords that aren't allowed.
       'assert',
@@ -268,7 +285,7 @@ class DBusCodeGenerator {
       'var',
       'void',
       'while',
-      'with'
+      'with',
     ];
 
     var argValues = <String>[];
@@ -345,7 +362,7 @@ class DBusCodeGenerator {
       String makeProperty(DBusIntrospectProperty property) {
         var args = [
           "'${property.name}'",
-          "DBusSignature('${property.type.value}')"
+          "DBusSignature('${property.type.value}')",
         ];
         if (property.access == DBusPropertyAccess.readwrite) {
           args.add('access: DBusPropertyAccess.readwrite');
@@ -393,8 +410,9 @@ class DBusCodeGenerator {
       var methodBranches = <_SwitchBranch>[];
       for (var method in interface.methods) {
         var argValues = <String>[];
-        var inputArgs = method.args
-            .where((arg) => arg.direction == DBusArgumentDirection.in_);
+        var inputArgs = method.args.where(
+          (arg) => arg.direction == DBusArgumentDirection.in_,
+        );
         String argCheck;
         if (inputArgs.isEmpty) {
           argCheck = 'methodCall.values.isNotEmpty';
@@ -411,7 +429,9 @@ class DBusCodeGenerator {
 
         var methodImplementation = 'do${method.name}(${argValues.join(', ')})';
         var isNoReply = _getBooleanAnnotation(
-            method.annotations, 'org.freedesktop.DBus.Method.NoReply');
+          method.annotations,
+          'org.freedesktop.DBus.Method.NoReply',
+        );
 
         var source = '';
         source += 'if ($argCheck) {\n';
@@ -423,13 +443,17 @@ class DBusCodeGenerator {
         } else {
           source += 'return $methodImplementation;\n';
         }
-        methodBranches
-            .add(_SwitchBranch("methodCall.name == '${method.name}'", source));
+        methodBranches.add(
+          _SwitchBranch("methodCall.name == '${method.name}'", source),
+        );
       }
       var source = _makeSwitch(
-          methodBranches, 'return DBusMethodErrorResponse.unknownMethod();\n');
+        methodBranches,
+        'return DBusMethodErrorResponse.unknownMethod();\n',
+      );
       interfaceBranches.add(
-          _SwitchBranch("methodCall.interface == '${interface.name}'", source));
+        _SwitchBranch("methodCall.interface == '${interface.name}'", source),
+      );
     }
 
     if (interfaceBranches.isEmpty) {
@@ -441,9 +465,12 @@ class DBusCodeGenerator {
     source +=
         '  Future<DBusMethodResponse> handleMethodCall(DBusMethodCall methodCall) async {\n';
     source += _indentSource(
-        2,
-        _makeSwitch(interfaceBranches,
-            'return DBusMethodErrorResponse.unknownInterface();\n'));
+      2,
+      _makeSwitch(
+        interfaceBranches,
+        'return DBusMethodErrorResponse.unknownInterface();\n',
+      ),
+    );
     source += '  }\n';
 
     return source;
@@ -451,7 +478,9 @@ class DBusCodeGenerator {
 
   // Generates a method that overrides DBusObject.getProperty().
   String _generateGetProperty(
-      Map<String, String> getMethodNames, DBusIntrospectNode node) {
+    Map<String, String> getMethodNames,
+    DBusIntrospectNode node,
+  ) {
     // Override DBusObject.getProperty().
     var interfaceBranches = <_SwitchBranch>[];
     for (var interface in node.interfaces) {
@@ -465,13 +494,17 @@ class DBusCodeGenerator {
         } else {
           source = 'return DBusMethodErrorResponse.propertyWriteOnly();\n';
         }
-        propertyBranches
-            .add(_SwitchBranch("name == '${property.name}'", source));
+        propertyBranches.add(
+          _SwitchBranch("name == '${property.name}'", source),
+        );
       }
-      var source = _makeSwitch(propertyBranches,
-          'return DBusMethodErrorResponse.unknownProperty();\n');
-      interfaceBranches
-          .add(_SwitchBranch("interface == '${interface.name}'", source));
+      var source = _makeSwitch(
+        propertyBranches,
+        'return DBusMethodErrorResponse.unknownProperty();\n',
+      );
+      interfaceBranches.add(
+        _SwitchBranch("interface == '${interface.name}'", source),
+      );
     }
 
     if (interfaceBranches.isEmpty) {
@@ -483,9 +516,12 @@ class DBusCodeGenerator {
     source +=
         '  Future<DBusMethodResponse> getProperty(String interface, String name) async {\n';
     source += _indentSource(
-        2,
-        _makeSwitch(interfaceBranches,
-            'return DBusMethodErrorResponse.unknownProperty();\n'));
+      2,
+      _makeSwitch(
+        interfaceBranches,
+        'return DBusMethodErrorResponse.unknownProperty();\n',
+      ),
+    );
     source += '  }\n';
 
     return source;
@@ -493,7 +529,9 @@ class DBusCodeGenerator {
 
   // Generates a method that overrides DBusObject.setProperty().
   String _generateSetProperty(
-      Map<String, String> setMethodNames, DBusIntrospectNode node) {
+    Map<String, String> setMethodNames,
+    DBusIntrospectNode node,
+  ) {
     var interfaceBranches = <_SwitchBranch>[];
     for (var interface in node.interfaces) {
       var propertyBranches = <_SwitchBranch>[];
@@ -513,13 +551,17 @@ class DBusCodeGenerator {
         } else {
           source = 'return DBusMethodErrorResponse.propertyReadOnly();\n';
         }
-        propertyBranches
-            .add(_SwitchBranch("name == '${property.name}'", source));
+        propertyBranches.add(
+          _SwitchBranch("name == '${property.name}'", source),
+        );
       }
-      var source = _makeSwitch(propertyBranches,
-          'return DBusMethodErrorResponse.unknownProperty();\n');
-      interfaceBranches
-          .add(_SwitchBranch("interface == '${interface.name}'", source));
+      var source = _makeSwitch(
+        propertyBranches,
+        'return DBusMethodErrorResponse.unknownProperty();\n',
+      );
+      interfaceBranches.add(
+        _SwitchBranch("interface == '${interface.name}'", source),
+      );
     }
 
     if (interfaceBranches.isEmpty) {
@@ -531,9 +573,12 @@ class DBusCodeGenerator {
     source +=
         '  Future<DBusMethodResponse> setProperty(String interface, String name, DBusValue value) async {\n';
     source += _indentSource(
-        2,
-        _makeSwitch(interfaceBranches,
-            'return DBusMethodErrorResponse.unknownProperty();\n'));
+      2,
+      _makeSwitch(
+        interfaceBranches,
+        'return DBusMethodErrorResponse.unknownProperty();\n',
+      ),
+    );
     source += '  }\n';
 
     return source;
@@ -552,8 +597,9 @@ class DBusCodeGenerator {
         }
       }
       if (source != '') {
-        interfaceBranches
-            .add(_SwitchBranch("interface == '${interface.name}'", source));
+        interfaceBranches.add(
+          _SwitchBranch("interface == '${interface.name}'", source),
+        );
       }
     }
 
@@ -585,7 +631,7 @@ class DBusCodeGenerator {
       'callMethod',
       'getAllProperties',
       'getProperty',
-      'setProperty'
+      'setProperty',
     ];
 
     for (var interface in node.interfaces) {
@@ -594,15 +640,28 @@ class DBusCodeGenerator {
         var lowerCaseName =
             signal.name[0].toLowerCase() + signal.name.substring(1);
         var variableName = _getUniqueMethodName(memberNames, lowerCaseName);
-        variables.add(_generateRemoteSignalVariable(
-            variableName, className, interface, signal));
-        variableConstructors.add(_generateRemoteSignalConstructor(
-            variableName, className, interface, signal));
+        variables.add(
+          _generateRemoteSignalVariable(
+            variableName,
+            className,
+            interface,
+            signal,
+          ),
+        );
+        variableConstructors.add(
+          _generateRemoteSignalConstructor(
+            variableName,
+            className,
+            interface,
+            signal,
+          ),
+        );
       }
 
       for (var property in interface.properties) {
         methods.addAll(
-            _generateRemotePropertyMethods(memberNames, interface, property));
+          _generateRemotePropertyMethods(memberNames, interface, property),
+        );
       }
 
       for (var method in interface.methods) {
@@ -643,8 +702,11 @@ class DBusCodeGenerator {
   }
 
   // Generate methods for the remote [property].
-  List<String> _generateRemotePropertyMethods(List<String> memberNames,
-      DBusIntrospectInterface interface, DBusIntrospectProperty property) {
+  List<String> _generateRemotePropertyMethods(
+    List<String> memberNames,
+    DBusIntrospectInterface interface,
+    DBusIntrospectProperty property,
+  ) {
     var methods = <String>[];
 
     var type = getDartType(property.type);
@@ -683,12 +745,17 @@ class DBusCodeGenerator {
   }
 
   // Generates a method for a remote D-Bus method call.
-  String _generateRemoteMethodCall(List<String> memberNames,
-      DBusIntrospectInterface interface, DBusIntrospectMethod method) {
-    var inputArgs =
-        method.args.where((arg) => arg.direction == DBusArgumentDirection.in_);
-    var outputArgs =
-        method.args.where((arg) => arg.direction == DBusArgumentDirection.out);
+  String _generateRemoteMethodCall(
+    List<String> memberNames,
+    DBusIntrospectInterface interface,
+    DBusIntrospectMethod method,
+  ) {
+    var inputArgs = method.args.where(
+      (arg) => arg.direction == DBusArgumentDirection.in_,
+    );
+    var outputArgs = method.args.where(
+      (arg) => arg.direction == DBusArgumentDirection.out,
+    );
 
     var argValues = <String>[];
     var argsList = <String>[];
@@ -702,10 +769,13 @@ class DBusCodeGenerator {
       index++;
     }
     argsList.add(
-        '{bool noAutoStart = false, bool allowInteractiveAuthorization = false}');
+      '{bool noAutoStart = false, bool allowInteractiveAuthorization = false}',
+    );
 
     var isNoReply = _getBooleanAnnotation(
-        method.annotations, 'org.freedesktop.DBus.Method.NoReply');
+      method.annotations,
+      'org.freedesktop.DBus.Method.NoReply',
+    );
 
     String returnType;
     if (isNoReply || outputArgs.isEmpty) {
@@ -721,14 +791,15 @@ class DBusCodeGenerator {
       "'${interface.name}'",
       "'${method.name}'",
       "[${argValues.join(', ')}]",
-      "replySignature: DBusSignature('${method.outputSignature.value}')"
+      "replySignature: DBusSignature('${method.outputSignature.value}')",
     ];
     if (isNoReply) {
       methodArgs.add('noReplyExpected: true');
     }
     methodArgs.add('noAutoStart: noAutoStart');
-    methodArgs
-        .add('allowInteractiveAuthorization: allowInteractiveAuthorization');
+    methodArgs.add(
+      'allowInteractiveAuthorization: allowInteractiveAuthorization',
+    );
     var methodCall = "await callMethod(${methodArgs.join(', ')});";
 
     var methodName = _getUniqueMethodName(memberNames, 'call${method.name}');
@@ -753,8 +824,11 @@ class DBusCodeGenerator {
   }
 
   // Generates a class to contain a signal response.
-  String _generateRemoteSignalClass(String classPrefix,
-      DBusIntrospectInterface interface, DBusIntrospectSignal signal) {
+  String _generateRemoteSignalClass(
+    String classPrefix,
+    DBusIntrospectInterface interface,
+    DBusIntrospectSignal signal,
+  ) {
     var argNames = [
       // Members of the DBusSignal class. Needs to be kept up to date.
       'interface',
@@ -796,7 +870,7 @@ class DBusCodeGenerator {
       'var',
       'void',
       'while',
-      'with'
+      'with',
     ];
 
     var properties = <String>[];
@@ -836,8 +910,12 @@ class DBusCodeGenerator {
   }
 
   // Generates a variable for a signal stream.
-  String _generateRemoteSignalVariable(String variableName, String classPrefix,
-      DBusIntrospectInterface interface, DBusIntrospectSignal signal) {
+  String _generateRemoteSignalVariable(
+    String variableName,
+    String classPrefix,
+    DBusIntrospectInterface interface,
+    DBusIntrospectSignal signal,
+  ) {
     var signalClassName = '$classPrefix${signal.name}';
 
     var source = '';
@@ -849,10 +927,11 @@ class DBusCodeGenerator {
 
   // Generates a constructor for a signal stream.
   String _generateRemoteSignalConstructor(
-      String variableName,
-      String classPrefix,
-      DBusIntrospectInterface interface,
-      DBusIntrospectSignal signal) {
+    String variableName,
+    String classPrefix,
+    DBusIntrospectInterface interface,
+    DBusIntrospectSignal signal,
+  ) {
     var signalClassName = '$classPrefix${signal.name}';
     return "    $variableName = DBusRemoteObjectSignalStream(object: this, interface: '${interface.name}', name: '${signal.name}', signature: DBusSignature('${signal.signature.value}')).asBroadcastStream().map((signal) => $signalClassName(signal));\n";
   }
@@ -885,8 +964,10 @@ class DBusCodeGenerator {
   }
 
   // Make switch (if/else) statement.
-  String _makeSwitch(Iterable<_SwitchBranch> branches,
-      [String? defaultBranch]) {
+  String _makeSwitch(
+    Iterable<_SwitchBranch> branches, [
+    String? defaultBranch,
+  ]) {
     if (branches.isEmpty) {
       return defaultBranch ?? '';
     }
@@ -923,7 +1004,9 @@ class DBusCodeGenerator {
   }
 
   String? _getAnnotation(
-      Iterable<DBusIntrospectAnnotation> annotations, String name) {
+    Iterable<DBusIntrospectAnnotation> annotations,
+    String name,
+  ) {
     for (var annotation in annotations) {
       if (annotation.name == name) {
         return annotation.value;
@@ -934,8 +1017,10 @@ class DBusCodeGenerator {
   }
 
   bool _getBooleanAnnotation(
-      Iterable<DBusIntrospectAnnotation> annotations, String name,
-      {bool defaultValue = false}) {
+    Iterable<DBusIntrospectAnnotation> annotations,
+    String name, {
+    bool defaultValue = false,
+  }) {
     var value = _getAnnotation(annotations, name);
     return value == null ? defaultValue : value == 'true';
   }

--- a/lib/src/dbus_code_generator.dart
+++ b/lib/src/dbus_code_generator.dart
@@ -62,7 +62,7 @@ class DBusCodeGenerator {
     var source = '';
 
     if (_comment != null) {
-      var escapedComment = _comment!.split('\n').join('\n// ');
+      var escapedComment = _comment.split('\n').join('\n// ');
       source += '// $escapedComment\n\n';
     }
 

--- a/lib/src/dbus_dart_type.dart
+++ b/lib/src/dbus_dart_type.dart
@@ -34,8 +34,9 @@ DBusDartType getDartType(DBusSignature signature) {
   } else if (value.startsWith('(') && value.endsWith(')')) {
     return DBusStructType();
   } else if (value.startsWith('a{') && value.endsWith('}')) {
-    var signatures =
-        DBusSignature(value.substring(2, value.length - 1)).split();
+    var signatures = DBusSignature(
+      value.substring(2, value.length - 1),
+    ).split();
     if (signatures.length != 2) {
       return DBusComplexType();
     }

--- a/lib/src/dbus_introspect.dart
+++ b/lib/src/dbus_introspect.dart
@@ -32,8 +32,11 @@ class DBusIntrospectNode {
   /// Child nodes.
   final List<DBusIntrospectNode> children;
 
-  DBusIntrospectNode(
-      {this.name, this.interfaces = const [], this.children = const []});
+  DBusIntrospectNode({
+    this.name,
+    this.interfaces = const [],
+    this.children = const [],
+  });
 
   factory DBusIntrospectNode.fromXml(XmlNode node) {
     var name = node.getAttribute('name');
@@ -46,7 +49,10 @@ class DBusIntrospectNode {
         .map((n) => DBusIntrospectNode.fromXml(n))
         .toList();
     return DBusIntrospectNode(
-        name: name, interfaces: interfaces, children: children);
+      name: name,
+      interfaces: interfaces,
+      children: children,
+    );
   }
 
   XmlNode toXml() {
@@ -65,7 +71,7 @@ class DBusIntrospectNode {
     var parameters = <String, String?>{
       'name': name != null ? '$name' : null,
       'interfaces': interfaces.isNotEmpty ? interfaces.toString() : null,
-      'children': children.isNotEmpty ? children.toString() : null
+      'children': children.isNotEmpty ? children.toString() : null,
     };
     var parameterString = parameters.keys
         .where((key) => parameters[key] != null)
@@ -102,11 +108,13 @@ class DBusIntrospectInterface {
   /// Annotations for this interface.
   final List<DBusIntrospectAnnotation> annotations;
 
-  DBusIntrospectInterface(this.name,
-      {this.methods = const [],
-      this.signals = const [],
-      this.properties = const [],
-      this.annotations = const []});
+  DBusIntrospectInterface(
+    this.name, {
+    this.methods = const [],
+    this.signals = const [],
+    this.properties = const [],
+    this.annotations = const [],
+  });
 
   factory DBusIntrospectInterface.fromXml(XmlNode node) {
     var name = node.getAttribute('name');
@@ -129,11 +137,13 @@ class DBusIntrospectInterface {
         .findElements('annotation')
         .map((n) => DBusIntrospectAnnotation.fromXml(n))
         .toList();
-    return DBusIntrospectInterface(name,
-        methods: methods,
-        signals: signals,
-        properties: properties,
-        annotations: annotations);
+    return DBusIntrospectInterface(
+      name,
+      methods: methods,
+      signals: signals,
+      properties: properties,
+      annotations: annotations,
+    );
   }
 
   XmlNode toXml() {
@@ -154,12 +164,14 @@ class DBusIntrospectInterface {
     var parameters = <String, String?>{
       'methods': methods.isNotEmpty ? methods.toString() : null,
       'signals': signals.isNotEmpty ? signals.toString() : null,
-      'properties': properties.isNotEmpty ? properties.toString() : null
+      'properties': properties.isNotEmpty ? properties.toString() : null,
     };
     var parameterString = ["'$name'"]
-        .followedBy(parameters.keys
-            .where((key) => parameters[key] != null)
-            .map((key) => '$key: ${parameters[key]}'))
+        .followedBy(
+          parameters.keys
+              .where((key) => parameters[key] != null)
+              .map((key) => '$key: ${parameters[key]}'),
+        )
         .join(', ');
     return '$runtimeType($parameterString)';
   }
@@ -201,8 +213,11 @@ class DBusIntrospectMethod {
       .map((arg) => arg.type)
       .fold(DBusSignature(''), (a, b) => a + b);
 
-  DBusIntrospectMethod(this.name,
-      {this.args = const [], this.annotations = const []});
+  DBusIntrospectMethod(
+    this.name, {
+    this.args = const [],
+    this.annotations = const [],
+  });
 
   factory DBusIntrospectMethod.fromXml(XmlNode node) {
     var name = node.getAttribute('name');
@@ -212,7 +227,8 @@ class DBusIntrospectMethod {
     var args = node
         .findElements('arg')
         .map(
-            (n) => DBusIntrospectArgument.fromXml(n, DBusArgumentDirection.in_))
+          (n) => DBusIntrospectArgument.fromXml(n, DBusArgumentDirection.in_),
+        )
         .toList();
     var annotations = node
         .findElements('annotation')
@@ -236,12 +252,14 @@ class DBusIntrospectMethod {
   String toString() {
     var parameters = <String, String?>{
       'args': args.isNotEmpty ? args.toString() : null,
-      'annotations': annotations.isNotEmpty ? annotations.toString() : null
+      'annotations': annotations.isNotEmpty ? annotations.toString() : null,
     };
     var parameterString = ["'$name'"]
-        .followedBy(parameters.keys
-            .where((key) => parameters[key] != null)
-            .map((key) => '$key: ${parameters[key]}'))
+        .followedBy(
+          parameters.keys
+              .where((key) => parameters[key] != null)
+              .map((key) => '$key: ${parameters[key]}'),
+        )
         .join(', ');
     return '$runtimeType($parameterString)';
   }
@@ -272,8 +290,11 @@ class DBusIntrospectSignal {
   DBusSignature get signature =>
       args.map((arg) => arg.type).fold(DBusSignature(''), (a, b) => a + b);
 
-  DBusIntrospectSignal(this.name,
-      {this.args = const [], this.annotations = const []});
+  DBusIntrospectSignal(
+    this.name, {
+    this.args = const [],
+    this.annotations = const [],
+  });
 
   factory DBusIntrospectSignal.fromXml(XmlNode node) {
     var name = node.getAttribute('name');
@@ -283,7 +304,8 @@ class DBusIntrospectSignal {
     var args = node
         .findElements('arg')
         .map(
-            (n) => DBusIntrospectArgument.fromXml(n, DBusArgumentDirection.out))
+          (n) => DBusIntrospectArgument.fromXml(n, DBusArgumentDirection.out),
+        )
         .toList();
     var annotations = node
         .findElements('annotation')
@@ -307,12 +329,14 @@ class DBusIntrospectSignal {
   String toString() {
     var parameters = <String, String?>{
       'args': args.isNotEmpty ? args.toString() : null,
-      'annotations': annotations.isNotEmpty ? annotations.toString() : null
+      'annotations': annotations.isNotEmpty ? annotations.toString() : null,
     };
     var parameterString = ["'$name'"]
-        .followedBy(parameters.keys
-            .where((key) => parameters[key] != null)
-            .map((key) => '$key: ${parameters[key]}'))
+        .followedBy(
+          parameters.keys
+              .where((key) => parameters[key] != null)
+              .map((key) => '$key: ${parameters[key]}'),
+        )
         .join(', ');
     return '$runtimeType($parameterString)';
   }
@@ -342,9 +366,12 @@ class DBusIntrospectProperty {
   /// Annotations for this property.
   final List<DBusIntrospectAnnotation> annotations;
 
-  DBusIntrospectProperty(this.name, this.type,
-      {this.access = DBusPropertyAccess.readwrite,
-      this.annotations = const []});
+  DBusIntrospectProperty(
+    this.name,
+    this.type, {
+    this.access = DBusPropertyAccess.readwrite,
+    this.annotations = const [],
+  });
 
   factory DBusIntrospectProperty.fromXml(XmlNode node) {
     var name = node.getAttribute('name');
@@ -361,7 +388,7 @@ class DBusIntrospectProperty {
       null: DBusPropertyAccess.readwrite,
       'readwrite': DBusPropertyAccess.readwrite,
       'read': DBusPropertyAccess.read,
-      'write': DBusPropertyAccess.write
+      'write': DBusPropertyAccess.write,
     }[accessText];
     if (access == null) {
       throw FormatException("Unknown property access '$accessText'");
@@ -370,8 +397,12 @@ class DBusIntrospectProperty {
         .findElements('annotation')
         .map((n) => DBusIntrospectAnnotation.fromXml(n))
         .toList();
-    return DBusIntrospectProperty(name, type,
-        access: access, annotations: annotations);
+    return DBusIntrospectProperty(
+      name,
+      type,
+      access: access,
+      annotations: annotations,
+    );
   }
 
   XmlNode toXml() {
@@ -395,14 +426,17 @@ class DBusIntrospectProperty {
   @override
   String toString() {
     var parameters = <String, String?>{
-      'access':
-          access != DBusPropertyAccess.readwrite ? access.toString() : null,
-      'annotations': annotations.isNotEmpty ? annotations.toString() : null
+      'access': access != DBusPropertyAccess.readwrite
+          ? access.toString()
+          : null,
+      'annotations': annotations.isNotEmpty ? annotations.toString() : null,
     };
     var parameterString = ["'$name'", type.toString()]
-        .followedBy(parameters.keys
-            .where((key) => parameters[key] != null)
-            .map((key) => '$key: ${parameters[key]}'))
+        .followedBy(
+          parameters.keys
+              .where((key) => parameters[key] != null)
+              .map((key) => '$key: ${parameters[key]}'),
+        )
         .join(', ');
     return '$runtimeType($parameterString)';
   }
@@ -433,11 +467,17 @@ class DBusIntrospectArgument {
   /// Annotations for this argument.
   final List<DBusIntrospectAnnotation> annotations;
 
-  DBusIntrospectArgument(this.type, this.direction,
-      {this.name, this.annotations = const []});
+  DBusIntrospectArgument(
+    this.type,
+    this.direction, {
+    this.name,
+    this.annotations = const [],
+  });
 
   factory DBusIntrospectArgument.fromXml(
-      XmlNode node, DBusArgumentDirection defaultDirection) {
+    XmlNode node,
+    DBusArgumentDirection defaultDirection,
+  ) {
     var name = node.getAttribute('name');
     var typeString = node.getAttribute('type');
     if (typeString == null) {
@@ -448,7 +488,7 @@ class DBusIntrospectArgument {
     var direction = {
       null: defaultDirection,
       'in': DBusArgumentDirection.in_,
-      'out': DBusArgumentDirection.out
+      'out': DBusArgumentDirection.out,
     }[directionText];
     if (direction == null) {
       throw FormatException("Unknown argument direction '$directionText'");
@@ -457,8 +497,12 @@ class DBusIntrospectArgument {
         .findElements('annotation')
         .map((n) => DBusIntrospectAnnotation.fromXml(n))
         .toList();
-    return DBusIntrospectArgument(type, direction,
-        name: name, annotations: annotations);
+    return DBusIntrospectArgument(
+      type,
+      direction,
+      name: name,
+      annotations: annotations,
+    );
   }
 
   XmlNode toXml({bool writeDirection = true}) {
@@ -485,12 +529,14 @@ class DBusIntrospectArgument {
   String toString() {
     var parameters = <String, String?>{
       'name': name != null ? "'$name'" : null,
-      'annotations': annotations.isNotEmpty ? annotations.toString() : null
+      'annotations': annotations.isNotEmpty ? annotations.toString() : null,
     };
     var parameterString = [type.toString(), direction.toString()]
-        .followedBy(parameters.keys
-            .where((key) => parameters[key] != null)
-            .map((key) => '$key: ${parameters[key]}'))
+        .followedBy(
+          parameters.keys
+              .where((key) => parameters[key] != null)
+              .map((key) => '$key: ${parameters[key]}'),
+        )
         .join(', ');
     return '$runtimeType($parameterString)';
   }
@@ -565,7 +611,8 @@ DBusIntrospectNode parseDBusIntrospectXml(String xml) {
   var nodeName = document.rootElement.name.local;
   if (nodeName != 'node') {
     throw FormatException(
-        "D-Bus Introspection XML has invalid root element '$nodeName', expected 'node'");
+      "D-Bus Introspection XML has invalid root element '$nodeName', expected 'node'",
+    );
   }
   return DBusIntrospectNode.fromXml(document.rootElement);
 }

--- a/lib/src/dbus_introspect.dart
+++ b/lib/src/dbus_introspect.dart
@@ -52,12 +52,12 @@ class DBusIntrospectNode {
   XmlNode toXml() {
     var attributes = <XmlAttribute>[];
     if (name != null) {
-      attributes.add(XmlAttribute(XmlName('name'), name!));
+      attributes.add(XmlAttribute(XmlName.parts('name'), name!));
     }
     var children_ = <XmlNode>[];
     children_.addAll(interfaces.map((i) => i.toXml()));
     children_.addAll(children.map((c) => c.toXml()));
-    return XmlElement(XmlName('node'), attributes, children_);
+    return XmlElement.tag('node', attributes: attributes, children: children_);
   }
 
   @override
@@ -142,8 +142,11 @@ class DBusIntrospectInterface {
     children.addAll(signals.map((s) => s.toXml()));
     children.addAll(properties.map((p) => p.toXml()));
     children.addAll(annotations.map((a) => a.toXml()));
-    return XmlElement(
-        XmlName('interface'), [XmlAttribute(XmlName('name'), name)], children);
+    return XmlElement.tag(
+      'interface',
+      attributes: [XmlAttribute(XmlName.parts('name'), name)],
+      children: children,
+    );
   }
 
   @override
@@ -222,8 +225,11 @@ class DBusIntrospectMethod {
     var children = <XmlNode>[];
     children.addAll(args.map((a) => a.toXml()));
     children.addAll(annotations.map((a) => a.toXml()));
-    return XmlElement(
-        XmlName('method'), [XmlAttribute(XmlName('name'), name)], children);
+    return XmlElement.tag(
+      'method',
+      attributes: [XmlAttribute(XmlName.parts('name'), name)],
+      children: children,
+    );
   }
 
   @override
@@ -290,8 +296,11 @@ class DBusIntrospectSignal {
     var children = <XmlNode>[];
     children.addAll(args.map((a) => a.toXml(writeDirection: false)));
     children.addAll(annotations.map((a) => a.toXml()));
-    return XmlElement(
-        XmlName('signal'), [XmlAttribute(XmlName('name'), name)], children);
+    return XmlElement.tag(
+      'signal',
+      attributes: [XmlAttribute(XmlName.parts('name'), name)],
+      children: children,
+    );
   }
 
   @override
@@ -367,17 +376,20 @@ class DBusIntrospectProperty {
 
   XmlNode toXml() {
     var attributes = <XmlAttribute>[];
-    attributes.add(XmlAttribute(XmlName('name'), name));
-    attributes.add(XmlAttribute(XmlName('type'), type.value));
+    attributes.add(XmlAttribute(XmlName.parts('name'), name));
+    attributes.add(XmlAttribute(XmlName.parts('type'), type.value));
     if (access == DBusPropertyAccess.readwrite) {
-      attributes.add(XmlAttribute(XmlName('access'), 'readwrite'));
+      attributes.add(XmlAttribute(XmlName.parts('access'), 'readwrite'));
     } else if (access == DBusPropertyAccess.read) {
-      attributes.add(XmlAttribute(XmlName('access'), 'read'));
+      attributes.add(XmlAttribute(XmlName.parts('access'), 'read'));
     } else if (access == DBusPropertyAccess.write) {
-      attributes.add(XmlAttribute(XmlName('access'), 'write'));
+      attributes.add(XmlAttribute(XmlName.parts('access'), 'write'));
     }
-    return XmlElement(XmlName('property'), attributes,
-        annotations.map((a) => a.toXml()).toList());
+    return XmlElement.tag(
+      'property',
+      attributes: attributes,
+      children: annotations.map((a) => a.toXml()).toList(),
+    );
   }
 
   @override
@@ -452,18 +464,21 @@ class DBusIntrospectArgument {
   XmlNode toXml({bool writeDirection = true}) {
     var attributes = <XmlAttribute>[];
     if (name != null) {
-      attributes.add(XmlAttribute(XmlName('name'), name!));
+      attributes.add(XmlAttribute(XmlName.parts('name'), name!));
     }
-    attributes.add(XmlAttribute(XmlName('type'), type.value));
+    attributes.add(XmlAttribute(XmlName.parts('type'), type.value));
     if (writeDirection) {
       if (direction == DBusArgumentDirection.in_) {
-        attributes.add(XmlAttribute(XmlName('direction'), 'in'));
+        attributes.add(XmlAttribute(XmlName.parts('direction'), 'in'));
       } else if (direction == DBusArgumentDirection.out) {
-        attributes.add(XmlAttribute(XmlName('direction'), 'out'));
+        attributes.add(XmlAttribute(XmlName.parts('direction'), 'out'));
       }
     }
-    return XmlElement(
-        XmlName('arg'), attributes, annotations.map((a) => a.toXml()).toList());
+    return XmlElement.tag(
+      'arg',
+      attributes: attributes,
+      children: annotations.map((a) => a.toXml()).toList(),
+    );
   }
 
   @override
@@ -515,10 +530,13 @@ class DBusIntrospectAnnotation {
   }
 
   XmlNode toXml() {
-    return XmlElement(XmlName('annotation'), [
-      XmlAttribute(XmlName('name'), name),
-      XmlAttribute(XmlName('value'), value)
-    ]);
+    return XmlElement.tag(
+      'annotation',
+      attributes: [
+        XmlAttribute(XmlName.parts('name'), name),
+        XmlAttribute(XmlName.parts('value'), value),
+      ],
+    );
   }
 
   @override

--- a/lib/src/dbus_introspectable.dart
+++ b/lib/src/dbus_introspectable.dart
@@ -9,19 +9,28 @@ import 'dbus_value.dart';
 
 /// Returns introspection data for the org.freedesktop.DBus.Introspectable interface.
 DBusIntrospectInterface introspectIntrospectable() {
-  final introspectMethod = DBusIntrospectMethod('Introspect', args: [
-    DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.out,
-        name: 'xml_data')
-  ]);
+  final introspectMethod = DBusIntrospectMethod(
+    'Introspect',
+    args: [
+      DBusIntrospectArgument(
+        DBusSignature('s'),
+        DBusArgumentDirection.out,
+        name: 'xml_data',
+      ),
+    ],
+  );
   final introspectable = DBusIntrospectInterface(
-      'org.freedesktop.DBus.Introspectable',
-      methods: [introspectMethod]);
+    'org.freedesktop.DBus.Introspectable',
+    methods: [introspectMethod],
+  );
   return introspectable;
 }
 
 /// Handles method calls on the org.freedesktop.DBus.Introspectable interface.
 DBusMethodResponse handleIntrospectableMethodCall(
-    DBusObjectTreeNode? node, DBusMethodCall methodCall) {
+  DBusObjectTreeNode? node,
+  DBusMethodCall methodCall,
+) {
   if (methodCall.name == 'Introspect') {
     if (methodCall.signature != DBusSignature('')) {
       return DBusMethodErrorResponse.invalidArgs();
@@ -41,11 +50,13 @@ DBusMethodResponse handleIntrospectableMethodCall(
     var children = <DBusIntrospectNode>[];
     if (node != null) {
       children.addAll(
-          node.children.keys.map((name) => DBusIntrospectNode(name: name)));
+        node.children.keys.map((name) => DBusIntrospectNode(name: name)),
+      );
     }
-    var xml = DBusIntrospectNode(interfaces: interfaces, children: children)
-        .toXml()
-        .toXmlString();
+    var xml = DBusIntrospectNode(
+      interfaces: interfaces,
+      children: children,
+    ).toXml().toXmlString();
     return DBusMethodSuccessResponse([DBusString(xml)]);
   } else {
     return DBusMethodErrorResponse.unknownMethod();

--- a/lib/src/dbus_match_rule.dart
+++ b/lib/src/dbus_match_rule.dart
@@ -32,13 +32,14 @@ class DBusMatchRule {
   final DBusObjectPath? pathNamespace;
 
   /// Creates a new D-Bus rule to match messages.
-  const DBusMatchRule(
-      {this.type,
-      this.sender,
-      this.interface,
-      this.member,
-      this.path,
-      this.pathNamespace});
+  const DBusMatchRule({
+    this.type,
+    this.sender,
+    this.interface,
+    this.member,
+    this.path,
+    this.pathNamespace,
+  });
 
   /// Creates a match rule from the string [rule] which is in the format used by D-Bus messages.
   factory DBusMatchRule.fromDBusString(String rule) {
@@ -50,14 +51,16 @@ class DBusMatchRule {
       if (rule[offset] == '=' || rule[offset] == ',') {
         throw DBusMatchRuleException('Invalid D-Bus rule, missing key');
       }
-      while (
-          offset < rule.length && rule[offset] != '=' && rule[offset] != ',') {
+      while (offset < rule.length &&
+          rule[offset] != '=' &&
+          rule[offset] != ',') {
         offset++;
       }
       var key = rule.substring(keyStart, offset);
       if (offset >= rule.length || rule[offset] != '=') {
         throw DBusMatchRuleException(
-            'Invalid D-Bus rule, key $key missing value');
+          'Invalid D-Bus rule, key $key missing value',
+        );
       }
       offset++;
 
@@ -79,7 +82,8 @@ class DBusMatchRule {
           offset++;
           if (offset >= rule.length) {
             throw DBusMatchRuleException(
-                'Invalid D-Bus rule, missing key after comma');
+              'Invalid D-Bus rule, missing key after comma',
+            );
           }
           break;
         }
@@ -100,7 +104,7 @@ class DBusMatchRule {
         'method_call': DBusMessageType.methodCall,
         'method_return': DBusMessageType.methodReturn,
         'error': DBusMessageType.error,
-        'signal': DBusMessageType.signal
+        'signal': DBusMessageType.signal,
       }[valueType];
       if (type == null) {
         throw DBusMatchRuleException('Invalid message type $valueType');
@@ -109,7 +113,8 @@ class DBusMatchRule {
 
     if (values['path'] != null && values['path_namespace'] != null) {
       throw DBusMatchRuleException(
-          "Match rule can't contain both path and path_namespace");
+        "Match rule can't contain both path and path_namespace",
+      );
     }
 
     return DBusMatchRule(
@@ -118,8 +123,9 @@ class DBusMatchRule {
       interface: values['interface'] != null
           ? DBusInterfaceName(values['interface']!)
           : null,
-      member:
-          values['member'] != null ? DBusMemberName(values['member']!) : null,
+      member: values['member'] != null
+          ? DBusMemberName(values['member']!)
+          : null,
       path: values['path'] != null ? DBusObjectPath(values['path']!) : null,
       pathNamespace: values['path_namespace'] != null
           ? DBusObjectPath(values['path_namespace']!)
@@ -131,11 +137,12 @@ class DBusMatchRule {
   String toDBusString() {
     var matches = <String, String>{};
     if (type != null) {
-      matches['type'] = {
+      matches['type'] =
+          {
             DBusMessageType.methodCall: 'method_call',
             DBusMessageType.methodReturn: 'method_return',
             DBusMessageType.error: 'error',
-            DBusMessageType.signal: 'signal'
+            DBusMessageType.signal: 'signal',
           }[type] ??
           '';
     }
@@ -167,12 +174,13 @@ class DBusMatchRule {
   }
 
   /// True if the rule matches the supplied values.
-  bool match(
-      {DBusMessageType? type,
-      DBusBusName? sender,
-      DBusInterfaceName? interface,
-      DBusMemberName? member,
-      DBusObjectPath? path}) {
+  bool match({
+    DBusMessageType? type,
+    DBusBusName? sender,
+    DBusInterfaceName? interface,
+    DBusMemberName? member,
+    DBusObjectPath? path,
+  }) {
     if (this.type != null && this.type != type) {
       return false;
     }
@@ -219,7 +227,7 @@ class DBusMatchRule {
       'interface': interface?.toString(),
       'member': member?.toString(),
       'path': path?.toString(),
-      'pathNamespace': pathNamespace?.toString()
+      'pathNamespace': pathNamespace?.toString(),
     };
     var parameterString = parameters.keys
         .where((key) => parameters[key] != null)

--- a/lib/src/dbus_message.dart
+++ b/lib/src/dbus_message.dart
@@ -11,7 +11,7 @@ enum DBusMessageType { methodCall, methodReturn, error, signal }
 enum DBusMessageFlag {
   noReplyExpected,
   noAutoStart,
-  allowInteractiveAuthorization
+  allowInteractiveAuthorization,
 }
 
 /// A message sent to/from the D-Bus server.
@@ -54,17 +54,19 @@ class DBusMessage {
       DBusSignature(values.map((value) => value.signature.value).join());
 
   /// Creates a new D-Bus message.
-  DBusMessage(this.type,
-      {this.flags = const {},
-      this.serial = 0,
-      this.path,
-      this.interface,
-      this.member,
-      this.errorName,
-      this.replySerial,
-      this.destination,
-      this.sender,
-      this.values = const []});
+  DBusMessage(
+    this.type, {
+    this.flags = const {},
+    this.serial = 0,
+    this.path,
+    this.interface,
+    this.member,
+    this.errorName,
+    this.replySerial,
+    this.destination,
+    this.sender,
+    this.values = const [],
+  });
 
   @override
   String toString() {
@@ -79,7 +81,7 @@ class DBusMessage {
       'replySerial': replySerial?.toString(),
       'destination': destination?.toString(),
       'sender': sender?.toString(),
-      'values': values.isNotEmpty ? values.toString() : null
+      'values': values.isNotEmpty ? values.toString() : null,
     };
     var parameterString = parameters.keys
         .where((key) => parameters[key] != null)

--- a/lib/src/dbus_method_call.dart
+++ b/lib/src/dbus_method_call.dart
@@ -28,14 +28,15 @@ class DBusMethodCall {
       .map((value) => value.signature)
       .fold(DBusSignature(''), (a, b) => a + b);
 
-  const DBusMethodCall(
-      {required this.sender,
-      this.interface,
-      required this.name,
-      this.values = const [],
-      this.noReplyExpected = false,
-      this.noAutoStart = false,
-      this.allowInteractiveAuthorization = false});
+  const DBusMethodCall({
+    required this.sender,
+    this.interface,
+    required this.name,
+    this.values = const [],
+    this.noReplyExpected = false,
+    this.noAutoStart = false,
+    this.allowInteractiveAuthorization = false,
+  });
 
   @override
   String toString() {
@@ -46,8 +47,9 @@ class DBusMethodCall {
       'values': values.isNotEmpty ? values.toString() : null,
       'noReplyExpected': noReplyExpected ? 'true' : null,
       'noAutoStart': noAutoStart ? 'true' : null,
-      'allowInteractiveAuthorization':
-          allowInteractiveAuthorization ? 'true' : null
+      'allowInteractiveAuthorization': allowInteractiveAuthorization
+          ? 'true'
+          : null,
     };
     var parameterString = parameters.keys
         .where((key) => parameters[key] != null)

--- a/lib/src/dbus_method_response.dart
+++ b/lib/src/dbus_method_response.dart
@@ -68,79 +68,72 @@ class DBusErrorException extends DBusMethodResponseException {
 
 /// Exception when a general failure occurs.
 class DBusFailedException extends DBusErrorException {
-  DBusFailedException(DBusMethodErrorResponse response) : super(response);
+  DBusFailedException(super.response);
 }
 
 /// Exception when there is no service providing the requested bus name.
 class DBusServiceUnknownException extends DBusErrorException {
-  DBusServiceUnknownException(DBusMethodErrorResponse response)
-      : super(response);
+  DBusServiceUnknownException(super.response);
 }
 
 /// Exception when an unknown object was requested.
 class DBusUnknownObjectException extends DBusErrorException {
-  DBusUnknownObjectException(DBusMethodErrorResponse response)
-      : super(response);
+  DBusUnknownObjectException(super.response);
 }
 
 /// Exception when an unknown interface was requested.
 class DBusUnknownInterfaceException extends DBusErrorException {
-  DBusUnknownInterfaceException(DBusMethodErrorResponse response)
-      : super(response);
+  DBusUnknownInterfaceException(super.response);
 }
 
 /// Exception when an unknown method was requested.
 class DBusUnknownMethodException extends DBusErrorException {
-  DBusUnknownMethodException(DBusMethodErrorResponse response)
-      : super(response);
+  DBusUnknownMethodException(super.response);
 }
 
 /// Exception when a request times out.
 class DBusTimeoutException extends DBusErrorException {
-  DBusTimeoutException(DBusMethodErrorResponse response) : super(response);
+  DBusTimeoutException(super.response);
 }
 
 /// Exception when a request times out.
 class DBusTimedOutException extends DBusErrorException {
-  DBusTimedOutException(DBusMethodErrorResponse response) : super(response);
+  DBusTimedOutException(super.response);
 }
 
 /// Exception when invalid arguments were provided to a method call.
 class DBusInvalidArgsException extends DBusErrorException {
-  DBusInvalidArgsException(DBusMethodErrorResponse response) : super(response);
+  DBusInvalidArgsException(super.response);
 }
 
 /// Exception when an unknown property was requested.
 class DBusUnknownPropertyException extends DBusErrorException {
-  DBusUnknownPropertyException(DBusMethodErrorResponse response)
-      : super(response);
+  DBusUnknownPropertyException(super.response);
 }
 
 /// Exception when a read-only property was written to.
 class DBusPropertyReadOnlyException extends DBusErrorException {
-  DBusPropertyReadOnlyException(DBusMethodErrorResponse response)
-      : super(response);
+  DBusPropertyReadOnlyException(super.response);
 }
 
 /// Exception when a write-only property was read from.
 class DBusPropertyWriteOnlyException extends DBusErrorException {
-  DBusPropertyWriteOnlyException(DBusMethodErrorResponse response)
-      : super(response);
+  DBusPropertyWriteOnlyException(super.response);
 }
 
 /// Exception when accessing a feature that is not supported.
 class DBusNotSupportedException extends DBusErrorException {
-  DBusNotSupportedException(DBusMethodErrorResponse response) : super(response);
+  DBusNotSupportedException(super.response);
 }
 
 /// Exception when access was denied to the requested resource.
 class DBusAccessDeniedException extends DBusErrorException {
-  DBusAccessDeniedException(DBusMethodErrorResponse response) : super(response);
+  DBusAccessDeniedException(super.response);
 }
 
 /// Exception when authentication failed accessing the requested resource.
 class DBusAuthFailedException extends DBusErrorException {
-  DBusAuthFailedException(DBusMethodErrorResponse response) : super(response);
+  DBusAuthFailedException(super.response);
 }
 
 /// An error response to a method call.

--- a/lib/src/dbus_method_response.dart
+++ b/lib/src/dbus_method_response.dart
@@ -149,68 +149,94 @@ class DBusMethodErrorResponse extends DBusMethodResponse {
 
   /// Creates a new error response indicating the request failed.
   DBusMethodErrorResponse.failed([String? message])
-      : this('org.freedesktop.DBus.Error.Failed',
-            message != null ? [DBusString(message)] : []);
+    : this(
+        'org.freedesktop.DBus.Error.Failed',
+        message != null ? [DBusString(message)] : [],
+      );
 
   /// Creates a new error response indicating an unknown object.
   DBusMethodErrorResponse.unknownObject([String? message])
-      : this('org.freedesktop.DBus.Error.UnknownObject',
-            message != null ? [DBusString(message)] : []);
+    : this(
+        'org.freedesktop.DBus.Error.UnknownObject',
+        message != null ? [DBusString(message)] : [],
+      );
 
   /// Creates a new error response indicating an unknown interface.
   DBusMethodErrorResponse.unknownInterface([String? message])
-      : this('org.freedesktop.DBus.Error.UnknownInterface',
-            message != null ? [DBusString(message)] : []);
+    : this(
+        'org.freedesktop.DBus.Error.UnknownInterface',
+        message != null ? [DBusString(message)] : [],
+      );
 
   /// Creates a new error response indicating an unknown method.
   DBusMethodErrorResponse.unknownMethod([String? message])
-      : this('org.freedesktop.DBus.Error.UnknownMethod',
-            message != null ? [DBusString(message)] : []);
+    : this(
+        'org.freedesktop.DBus.Error.UnknownMethod',
+        message != null ? [DBusString(message)] : [],
+      );
 
   /// Creates a new error response indicating the request timed out.
   DBusMethodErrorResponse.timeout([String? message])
-      : this('org.freedesktop.DBus.Error.Timeout',
-            message != null ? [DBusString(message)] : []);
+    : this(
+        'org.freedesktop.DBus.Error.Timeout',
+        message != null ? [DBusString(message)] : [],
+      );
 
   /// Creates a new error response indicating the request timed out.
   DBusMethodErrorResponse.timedOut([String? message])
-      : this('org.freedesktop.DBus.Error.TimedOut',
-            message != null ? [DBusString(message)] : []);
+    : this(
+        'org.freedesktop.DBus.Error.TimedOut',
+        message != null ? [DBusString(message)] : [],
+      );
 
   /// Creates a new error response indicating the arguments passed were invalid.
   DBusMethodErrorResponse.invalidArgs([String? message])
-      : this('org.freedesktop.DBus.Error.InvalidArgs',
-            message != null ? [DBusString(message)] : []);
+    : this(
+        'org.freedesktop.DBus.Error.InvalidArgs',
+        message != null ? [DBusString(message)] : [],
+      );
 
   /// Creates a new error response indicating an unknown property.
   DBusMethodErrorResponse.unknownProperty([String? message])
-      : this('org.freedesktop.DBus.Error.UnknownProperty',
-            message != null ? [DBusString(message)] : []);
+    : this(
+        'org.freedesktop.DBus.Error.UnknownProperty',
+        message != null ? [DBusString(message)] : [],
+      );
 
   /// Creates a new error response when attempting to write to a read-only property.
   DBusMethodErrorResponse.propertyReadOnly([String? message])
-      : this('org.freedesktop.DBus.Error.PropertyReadOnly',
-            message != null ? [DBusString(message)] : []);
+    : this(
+        'org.freedesktop.DBus.Error.PropertyReadOnly',
+        message != null ? [DBusString(message)] : [],
+      );
 
   /// Creates a new error response when attempting to read to a write-only property.
   DBusMethodErrorResponse.propertyWriteOnly([String? message])
-      : this('org.freedesktop.DBus.Error.PropertyWriteOnly',
-            message != null ? [DBusString(message)] : []);
+    : this(
+        'org.freedesktop.DBus.Error.PropertyWriteOnly',
+        message != null ? [DBusString(message)] : [],
+      );
 
   /// Creates a new error response when accessing an unsupported feature.
   DBusMethodErrorResponse.notSupported([String? message])
-      : this('org.freedesktop.DBus.Error.NotSupported',
-            message != null ? [DBusString(message)] : []);
+    : this(
+        'org.freedesktop.DBus.Error.NotSupported',
+        message != null ? [DBusString(message)] : [],
+      );
 
   /// Creates a new error response indicating access was denied.
   DBusMethodErrorResponse.accessDenied([String? message])
-      : this('org.freedesktop.DBus.Error.AccessDenied',
-            message != null ? [DBusString(message)] : []);
+    : this(
+        'org.freedesktop.DBus.Error.AccessDenied',
+        message != null ? [DBusString(message)] : [],
+      );
 
   /// Creates a new error response indicating authentication failed.
   DBusMethodErrorResponse.authFailed([String? message])
-      : this('org.freedesktop.DBus.Error.AuthFailed',
-            message != null ? [DBusString(message)] : []);
+    : this(
+        'org.freedesktop.DBus.Error.AuthFailed',
+        message != null ? [DBusString(message)] : [],
+      );
 
   @override
   List<DBusValue> get returnValues => throw DBusMethodResponseException(this);
@@ -230,7 +256,7 @@ class DBusGetPropertyResponse extends DBusMethodSuccessResponse {
 /// A successful response to [DBusObject.getAllProperties].
 class DBusGetAllPropertiesResponse extends DBusMethodSuccessResponse {
   DBusGetAllPropertiesResponse(Map<String, DBusValue> values)
-      : super([DBusDict.stringVariant(values)]);
+    : super([DBusDict.stringVariant(values)]);
 
   @override
   String toString() => '$runtimeType(${values[0].asStringVariantDict()})';

--- a/lib/src/dbus_object.dart
+++ b/lib/src/dbus_object.dart
@@ -39,7 +39,10 @@ class DBusObject {
 
   /// Called when a property is set on this object. On success, return [DBusMethodSuccessResponse].
   Future<DBusMethodResponse> setProperty(
-      String interface, String name, DBusValue value) async {
+    String interface,
+    String name,
+    DBusValue value,
+  ) async {
     return DBusMethodErrorResponse.unknownProperty();
   }
 
@@ -49,53 +52,77 @@ class DBusObject {
   }
 
   /// Emits a signal on this object.
-  Future<void> emitSignal(String interface, String name,
-      [Iterable<DBusValue> values = const []]) async {
+  Future<void> emitSignal(
+    String interface,
+    String name, [
+    Iterable<DBusValue> values = const [],
+  ]) async {
     await client?.emitSignal(
-        path: path, interface: interface, name: name, values: values);
+      path: path,
+      interface: interface,
+      name: name,
+      values: values,
+    );
   }
 
   /// Emits org.freedesktop.DBus.Properties.PropertiesChanged on this object.
-  Future<void> emitPropertiesChanged(String interface,
-      {Map<String, DBusValue> changedProperties = const {},
-      List<String> invalidatedProperties = const []}) async {
+  Future<void> emitPropertiesChanged(
+    String interface, {
+    Map<String, DBusValue> changedProperties = const {},
+    List<String> invalidatedProperties = const [],
+  }) async {
     await emitSignal('org.freedesktop.DBus.Properties', 'PropertiesChanged', [
       DBusString(interface),
       DBusDict.stringVariant(changedProperties),
-      DBusArray(DBusSignature('s'),
-          invalidatedProperties.map((name) => DBusString(name)))
+      DBusArray(
+        DBusSignature('s'),
+        invalidatedProperties.map((name) => DBusString(name)),
+      ),
     ]);
   }
 
   /// Emits org.freedesktop.DBus.ObjectManager.InterfacesAdded on this object.
   /// [path] is the path to the object that has been added or changed.
   /// [interfacesAndProperties] is the interfaces added to the object at [path] and the properties this object has.
-  Future<void> emitInterfacesAdded(DBusObjectPath path,
-      Map<String, Map<String, DBusValue>> interfacesAndProperties) async {
+  Future<void> emitInterfacesAdded(
+    DBusObjectPath path,
+    Map<String, Map<String, DBusValue>> interfacesAndProperties,
+  ) async {
     DBusValue encodeProperties(Map<String, DBusValue> properties) =>
         DBusDict.stringVariant(properties);
     DBusValue encodeInterfacesAndProperties(
-            Map<String, Map<String, DBusValue>> interfacesAndProperties) =>
-        DBusDict(
-            DBusSignature('s'),
-            DBusSignature('a{sv}'),
-            interfacesAndProperties.map<DBusValue, DBusValue>(
-                (name, properties) =>
-                    MapEntry(DBusString(name), encodeProperties(properties))));
-    await emitSignal('org.freedesktop.DBus.ObjectManager', 'InterfacesAdded',
-        [path, encodeInterfacesAndProperties(interfacesAndProperties)]);
+      Map<String, Map<String, DBusValue>> interfacesAndProperties,
+    ) => DBusDict(
+      DBusSignature('s'),
+      DBusSignature('a{sv}'),
+      interfacesAndProperties.map<DBusValue, DBusValue>(
+        (name, properties) =>
+            MapEntry(DBusString(name), encodeProperties(properties)),
+      ),
+    );
+    await emitSignal('org.freedesktop.DBus.ObjectManager', 'InterfacesAdded', [
+      path,
+      encodeInterfacesAndProperties(interfacesAndProperties),
+    ]);
   }
 
   /// Emits org.freedesktop.DBus.ObjectManager.InterfacesRemoved on this object.
   /// [path] is the path to the object is being removed or changed.
   /// [interfaces] is the names of the interfaces being removed from the object at [path].
   Future<void> emitInterfacesRemoved(
-      DBusObjectPath path, Iterable<String> interfaces) async {
+    DBusObjectPath path,
+    Iterable<String> interfaces,
+  ) async {
     await emitSignal(
-        'org.freedesktop.DBus.ObjectManager', 'InterfacesRemoved', [
-      path,
-      DBusArray(DBusSignature('s'),
-          interfaces.map((interface) => DBusString(interface)))
-    ]);
+      'org.freedesktop.DBus.ObjectManager',
+      'InterfacesRemoved',
+      [
+        path,
+        DBusArray(
+          DBusSignature('s'),
+          interfaces.map((interface) => DBusString(interface)),
+        ),
+      ],
+    );
   }
 }

--- a/lib/src/dbus_object_manager.dart
+++ b/lib/src/dbus_object_manager.dart
@@ -6,8 +6,9 @@ import 'dbus_object_tree.dart';
 import 'dbus_value.dart';
 
 Map<String, Map<String, DBusValue>> expandObjectInterfaceAndProperties(
-    DBusObject object,
-    {bool introspectable = true}) {
+  DBusObject object, {
+  bool introspectable = true,
+}) {
   var interfacesAndProperties = <String, Map<String, DBusValue>>{};
 
   // Start with the standard interfaces.
@@ -24,36 +25,60 @@ Map<String, Map<String, DBusValue>> expandObjectInterfaceAndProperties(
 
 /// Returns introspection data for the org.freedesktop.DBus.ObjectManager interface.
 DBusIntrospectInterface introspectObjectManager() {
-  final introspectMethod = DBusIntrospectMethod('GetManagedObjects', args: [
-    DBusIntrospectArgument(
-        DBusSignature('a{oa{sa{sv}}}'), DBusArgumentDirection.out,
-        name: 'objpath_interfaces_and_properties')
-  ]);
-  final interfacesAddedSignal = DBusIntrospectSignal('InterfacesAdded', args: [
-    DBusIntrospectArgument(DBusSignature('o'), DBusArgumentDirection.out,
-        name: 'object_path'),
-    DBusIntrospectArgument(
-        DBusSignature('a{sa{sv}}'), DBusArgumentDirection.out,
-        name: 'interfaces_and_properties')
-  ]);
-  final interfacesRemovedSignal =
-      DBusIntrospectSignal('InterfacesRemoved', args: [
-    DBusIntrospectArgument(DBusSignature('o'), DBusArgumentDirection.out,
-        name: 'object_path'),
-    DBusIntrospectArgument(DBusSignature('as'), DBusArgumentDirection.out,
-        name: 'interfaces')
-  ]);
+  final introspectMethod = DBusIntrospectMethod(
+    'GetManagedObjects',
+    args: [
+      DBusIntrospectArgument(
+        DBusSignature('a{oa{sa{sv}}}'),
+        DBusArgumentDirection.out,
+        name: 'objpath_interfaces_and_properties',
+      ),
+    ],
+  );
+  final interfacesAddedSignal = DBusIntrospectSignal(
+    'InterfacesAdded',
+    args: [
+      DBusIntrospectArgument(
+        DBusSignature('o'),
+        DBusArgumentDirection.out,
+        name: 'object_path',
+      ),
+      DBusIntrospectArgument(
+        DBusSignature('a{sa{sv}}'),
+        DBusArgumentDirection.out,
+        name: 'interfaces_and_properties',
+      ),
+    ],
+  );
+  final interfacesRemovedSignal = DBusIntrospectSignal(
+    'InterfacesRemoved',
+    args: [
+      DBusIntrospectArgument(
+        DBusSignature('o'),
+        DBusArgumentDirection.out,
+        name: 'object_path',
+      ),
+      DBusIntrospectArgument(
+        DBusSignature('as'),
+        DBusArgumentDirection.out,
+        name: 'interfaces',
+      ),
+    ],
+  );
   final introspectable = DBusIntrospectInterface(
-      'org.freedesktop.DBus.ObjectManager',
-      methods: [introspectMethod],
-      signals: [interfacesAddedSignal, interfacesRemovedSignal]);
+    'org.freedesktop.DBus.ObjectManager',
+    methods: [introspectMethod],
+    signals: [interfacesAddedSignal, interfacesRemovedSignal],
+  );
   return introspectable;
 }
 
 /// Handles method calls on the org.freedesktop.DBus.ObjectManager interface.
 DBusMethodResponse handleObjectManagerMethodCall(
-    DBusObjectTree objectTree, DBusMethodCall methodCall,
-    {bool introspectable = true}) {
+  DBusObjectTree objectTree,
+  DBusMethodCall methodCall, {
+  bool introspectable = true,
+}) {
   if (methodCall.name == 'GetManagedObjects') {
     var objpathInterfacesAndProperties = <DBusObjectPath, DBusValue>{};
     void addObjects(DBusObjectTreeNode node) {
@@ -62,18 +87,23 @@ DBusMethodResponse handleObjectManagerMethodCall(
         DBusValue encodeProperties(Map<String, DBusValue> properties) =>
             DBusDict.stringVariant(properties);
         DBusValue encodeInterfacesAndProperties(
-                Map<String, Map<String, DBusValue>> interfacesAndProperties) =>
-            DBusDict(
-                DBusSignature('s'),
-                DBusSignature('a{sv}'),
-                interfacesAndProperties.map<DBusValue, DBusValue>((name,
-                        properties) =>
-                    MapEntry(DBusString(name), encodeProperties(properties))));
+          Map<String, Map<String, DBusValue>> interfacesAndProperties,
+        ) => DBusDict(
+          DBusSignature('s'),
+          DBusSignature('a{sv}'),
+          interfacesAndProperties.map<DBusValue, DBusValue>(
+            (name, properties) =>
+                MapEntry(DBusString(name), encodeProperties(properties)),
+          ),
+        );
 
         objpathInterfacesAndProperties[object.path] =
-            encodeInterfacesAndProperties(expandObjectInterfaceAndProperties(
+            encodeInterfacesAndProperties(
+              expandObjectInterfaceAndProperties(
                 object,
-                introspectable: introspectable));
+                introspectable: introspectable,
+              ),
+            );
       }
       for (var childNode in node.children.values) {
         addObjects(childNode);
@@ -83,8 +113,11 @@ DBusMethodResponse handleObjectManagerMethodCall(
     addObjects(objectTree.root);
 
     return DBusMethodSuccessResponse([
-      DBusDict(DBusSignature('o'), DBusSignature('a{sa{sv}}'),
-          objpathInterfacesAndProperties)
+      DBusDict(
+        DBusSignature('o'),
+        DBusSignature('a{sa{sv}}'),
+        objpathInterfacesAndProperties,
+      ),
     ]);
   } else {
     return DBusMethodErrorResponse.unknownMethod();

--- a/lib/src/dbus_peer.dart
+++ b/lib/src/dbus_peer.dart
@@ -7,19 +7,28 @@ import 'dbus_value.dart';
 
 /// Returns introspection data for the org.freedesktop.DBus.Peer interface.
 DBusIntrospectInterface introspectPeer() {
-  final getMachineIdMethod = DBusIntrospectMethod('GetMachineId', args: [
-    DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.out,
-        name: 'machine_uuid')
-  ]);
+  final getMachineIdMethod = DBusIntrospectMethod(
+    'GetMachineId',
+    args: [
+      DBusIntrospectArgument(
+        DBusSignature('s'),
+        DBusArgumentDirection.out,
+        name: 'machine_uuid',
+      ),
+    ],
+  );
   final pingMethod = DBusIntrospectMethod('Ping');
-  final peer = DBusIntrospectInterface('org.freedesktop.DBus.Peer',
-      methods: [getMachineIdMethod, pingMethod]);
+  final peer = DBusIntrospectInterface(
+    'org.freedesktop.DBus.Peer',
+    methods: [getMachineIdMethod, pingMethod],
+  );
   return peer;
 }
 
 /// Handles method calls on the org.freedesktop.DBus.Peer interface.
 Future<DBusMethodResponse> handlePeerMethodCall(
-    DBusMethodCall methodCall) async {
+  DBusMethodCall methodCall,
+) async {
   if (methodCall.name == 'GetMachineId') {
     if (methodCall.signature != DBusSignature('')) {
       return DBusMethodErrorResponse.invalidArgs();

--- a/lib/src/dbus_properties.dart
+++ b/lib/src/dbus_properties.dart
@@ -6,47 +6,94 @@ import 'dbus_value.dart';
 
 /// Returns introspection data for the org.freedesktop.DBus.Properties interface.
 DBusIntrospectInterface introspectProperties() {
-  final getMethod = DBusIntrospectMethod('Get', args: [
-    DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.in_,
-        name: 'interface_name'),
-    DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.in_,
-        name: 'property_name'),
-    DBusIntrospectArgument(DBusSignature('v'), DBusArgumentDirection.out,
-        name: 'value'),
-  ]);
-  final setMethod = DBusIntrospectMethod('Set', args: [
-    DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.in_,
-        name: 'interface_name'),
-    DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.in_,
-        name: 'property_name'),
-    DBusIntrospectArgument(DBusSignature('v'), DBusArgumentDirection.in_,
-        name: 'value'),
-  ]);
-  final getAllMethod = DBusIntrospectMethod('GetAll', args: [
-    DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.in_,
-        name: 'interface_name'),
-    DBusIntrospectArgument(DBusSignature('a{sv}'), DBusArgumentDirection.out,
-        name: 'props'),
-  ]);
-  final propertiesChangedSignal =
-      DBusIntrospectSignal('PropertiesChanged', args: [
-    DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.out,
-        name: 'interface_name'),
-    DBusIntrospectArgument(DBusSignature('a{sv}'), DBusArgumentDirection.out,
-        name: 'changed_properties'),
-    DBusIntrospectArgument(DBusSignature('as'), DBusArgumentDirection.out,
-        name: 'invalidated_properties')
-  ]);
+  final getMethod = DBusIntrospectMethod(
+    'Get',
+    args: [
+      DBusIntrospectArgument(
+        DBusSignature('s'),
+        DBusArgumentDirection.in_,
+        name: 'interface_name',
+      ),
+      DBusIntrospectArgument(
+        DBusSignature('s'),
+        DBusArgumentDirection.in_,
+        name: 'property_name',
+      ),
+      DBusIntrospectArgument(
+        DBusSignature('v'),
+        DBusArgumentDirection.out,
+        name: 'value',
+      ),
+    ],
+  );
+  final setMethod = DBusIntrospectMethod(
+    'Set',
+    args: [
+      DBusIntrospectArgument(
+        DBusSignature('s'),
+        DBusArgumentDirection.in_,
+        name: 'interface_name',
+      ),
+      DBusIntrospectArgument(
+        DBusSignature('s'),
+        DBusArgumentDirection.in_,
+        name: 'property_name',
+      ),
+      DBusIntrospectArgument(
+        DBusSignature('v'),
+        DBusArgumentDirection.in_,
+        name: 'value',
+      ),
+    ],
+  );
+  final getAllMethod = DBusIntrospectMethod(
+    'GetAll',
+    args: [
+      DBusIntrospectArgument(
+        DBusSignature('s'),
+        DBusArgumentDirection.in_,
+        name: 'interface_name',
+      ),
+      DBusIntrospectArgument(
+        DBusSignature('a{sv}'),
+        DBusArgumentDirection.out,
+        name: 'props',
+      ),
+    ],
+  );
+  final propertiesChangedSignal = DBusIntrospectSignal(
+    'PropertiesChanged',
+    args: [
+      DBusIntrospectArgument(
+        DBusSignature('s'),
+        DBusArgumentDirection.out,
+        name: 'interface_name',
+      ),
+      DBusIntrospectArgument(
+        DBusSignature('a{sv}'),
+        DBusArgumentDirection.out,
+        name: 'changed_properties',
+      ),
+      DBusIntrospectArgument(
+        DBusSignature('as'),
+        DBusArgumentDirection.out,
+        name: 'invalidated_properties',
+      ),
+    ],
+  );
   final introspectable = DBusIntrospectInterface(
-      'org.freedesktop.DBus.Properties',
-      methods: [getMethod, setMethod, getAllMethod],
-      signals: [propertiesChangedSignal]);
+    'org.freedesktop.DBus.Properties',
+    methods: [getMethod, setMethod, getAllMethod],
+    signals: [propertiesChangedSignal],
+  );
   return introspectable;
 }
 
 /// Handles method calls on the org.freedesktop.DBus.Properties interface.
 Future<DBusMethodResponse> handlePropertiesMethodCall(
-    DBusObject object, DBusMethodCall methodCall) async {
+  DBusObject object,
+  DBusMethodCall methodCall,
+) async {
   if (methodCall.name == 'Get') {
     if (methodCall.signature != DBusSignature('ss')) {
       return DBusMethodErrorResponse.invalidArgs();

--- a/lib/src/dbus_read_buffer.dart
+++ b/lib/src/dbus_read_buffer.dart
@@ -53,7 +53,7 @@ class DBusReadBuffer extends DBusBuffer {
   /// Returns null if no line available.
   String? readLine() {
     for (var i = readOffset; i < _data.length - 1; i++) {
-      if (_data[i] == 13 /* '\r' */ && _data[i + 1] == 10 /* '\n' */) {
+      if (_data[i] == 13 /* '\r' */ && _data[i + 1] == 10 /* '\n' */ ) {
         var bytes = _data.getRange(readOffset, i);
         readOffset = i + 2;
         return utf8.decode(bytes.toList());
@@ -76,7 +76,7 @@ class DBusReadBuffer extends DBusBuffer {
       1: DBusMessageType.methodCall,
       2: DBusMessageType.methodReturn,
       3: DBusMessageType.error,
-      4: DBusMessageType.signal
+      4: DBusMessageType.signal,
     }[readDBusByte()!.value];
     if (type == null) {
       throw 'Invalid type received';
@@ -201,17 +201,19 @@ class DBusReadBuffer extends DBusBuffer {
     }
     _resourceHandles.removeRange(0, fdCount);
 
-    return DBusMessage(type,
-        flags: flags,
-        serial: serial,
-        path: path,
-        interface: interface,
-        member: member,
-        errorName: errorName,
-        replySerial: replySerial,
-        destination: destination,
-        sender: sender,
-        values: values);
+    return DBusMessage(
+      type,
+      flags: flags,
+      serial: serial,
+      path: path,
+      interface: interface,
+      member: member,
+      errorName: errorName,
+      replySerial: replySerial,
+      destination: destination,
+      sender: sender,
+      values: values,
+    );
   }
 
   /// Reads a 16 bit signed integer from the buffer.
@@ -391,8 +393,10 @@ class DBusReadBuffer extends DBusBuffer {
   }
 
   /// Reads a [DBusVariant] from the buffer or returns null if not enough data.
-  DBusVariant? readDBusVariant(
-      [Endian endian = Endian.little, int fdCount = 0]) {
+  DBusVariant? readDBusVariant([
+    Endian endian = Endian.little,
+    int fdCount = 0,
+  ]) {
     var signature = readDBusSignature();
     if (signature == null) {
       return null;
@@ -422,8 +426,11 @@ class DBusReadBuffer extends DBusBuffer {
   }
 
   /// Reads a [DBusStruct] from the buffer or returns null if not enough data.
-  DBusStruct? readDBusStruct(Iterable<DBusSignature> childSignatures,
-      [Endian endian = Endian.little, int fdCount = 0]) {
+  DBusStruct? readDBusStruct(
+    Iterable<DBusSignature> childSignatures, [
+    Endian endian = Endian.little,
+    int fdCount = 0,
+  ]) {
     if (!align(structAlignment)) {
       return null;
     }
@@ -441,8 +448,11 @@ class DBusReadBuffer extends DBusBuffer {
   }
 
   /// Reads a [DBusArray] from the buffer or returns null if not enough data.
-  DBusArray? readDBusArray(DBusSignature childSignature,
-      [Endian endian = Endian.little, int fdCount = 0]) {
+  DBusArray? readDBusArray(
+    DBusSignature childSignature, [
+    Endian endian = Endian.little,
+    int fdCount = 0,
+  ]) {
     var length = readDBusUint32(endian);
     if (length == null || !align(getAlignment(childSignature))) {
       return null;
@@ -462,8 +472,11 @@ class DBusReadBuffer extends DBusBuffer {
   }
 
   DBusDict? readDBusDict(
-      DBusSignature keySignature, DBusSignature valueSignature,
-      [Endian endian = Endian.little, int fdCount = 0]) {
+    DBusSignature keySignature,
+    DBusSignature valueSignature, [
+    Endian endian = Endian.little,
+    int fdCount = 0,
+  ]) {
     var length = readDBusUint32(endian);
     if (length == null || !align(dictEntryAlignment)) {
       return null;
@@ -486,8 +499,11 @@ class DBusReadBuffer extends DBusBuffer {
   }
 
   /// Reads a [DBusValue] with [signature].
-  DBusValue? readDBusValue(DBusSignature signature,
-      [Endian endian = Endian.little, int fdCount = 0]) {
+  DBusValue? readDBusValue(
+    DBusSignature signature, [
+    Endian endian = Endian.little,
+    int fdCount = 0,
+  ]) {
     var s = signature.value;
     if (s == 'y') {
       return readDBusByte();
@@ -533,10 +549,16 @@ class DBusReadBuffer extends DBusBuffer {
       return readDBusDict(keySignature, valueSignature, endian, fdCount);
     } else if (s.startsWith('a')) {
       return readDBusArray(
-          DBusSignature(s.substring(1, s.length)), endian, fdCount);
+        DBusSignature(s.substring(1, s.length)),
+        endian,
+        fdCount,
+      );
     } else if (s.startsWith('(') && s.endsWith(')')) {
       return readDBusStruct(
-          DBusSignature(s.substring(1, s.length - 1)).split(), endian, fdCount);
+        DBusSignature(s.substring(1, s.length - 1)).split(),
+        endian,
+        fdCount,
+      );
     } else {
       throw "Unknown D-Bus data type '$s'";
     }

--- a/lib/src/dbus_remote_object.dart
+++ b/lib/src/dbus_remote_object.dart
@@ -11,17 +11,19 @@ class DBusRemoteObjectSignalStream extends DBusSignalStream {
   /// If [signature] is provided this causes the stream to throw a
   /// [DBusSignalSignatureException] if a signal is received that does not
   /// match the provided signature.
-  DBusRemoteObjectSignalStream(
-      {required DBusRemoteObject object,
-      required String interface,
-      required String name,
-      DBusSignature? signature})
-      : super(object.client,
-            sender: object.name,
-            path: object.path,
-            interface: interface,
-            name: name,
-            signature: signature);
+  DBusRemoteObjectSignalStream({
+    required DBusRemoteObject object,
+    required String interface,
+    required String name,
+    DBusSignature? signature,
+  }) : super(
+         object.client,
+         sender: object.name,
+         path: object.path,
+         interface: interface,
+         name: name,
+         signature: signature,
+       );
 }
 
 /// Signal received when properties are changed.
@@ -37,12 +39,13 @@ class DBusPropertiesChangedSignal extends DBusSignal {
   List<String> get invalidatedProperties => values[2].asStringArray().toList();
 
   DBusPropertiesChangedSignal(DBusSignal signal)
-      : super(
-            sender: signal.sender,
-            path: signal.path,
-            interface: signal.interface,
-            name: signal.name,
-            values: signal.values);
+    : super(
+        sender: signal.sender,
+        path: signal.path,
+        interface: signal.interface,
+        name: signal.name,
+        values: signal.values,
+      );
 }
 
 /// Exception thrown when a D-Bus property returns a value that don't match the expected signature.
@@ -78,9 +81,10 @@ class DBusRemoteObject {
   /// Creates an object that access accesses a remote D-Bus object using bus [name] with [path].
   DBusRemoteObject(this.client, {required this.name, required this.path}) {
     var rawPropertiesChanged = DBusRemoteObjectSignalStream(
-        object: this,
-        interface: 'org.freedesktop.DBus.Properties',
-        name: 'PropertiesChanged');
+      object: this,
+      interface: 'org.freedesktop.DBus.Properties',
+      name: 'PropertiesChanged',
+    );
     propertiesChanged = rawPropertiesChanged.map((signal) {
       if (signal.signature == DBusSignature('sa{sv}as')) {
         return DBusPropertiesChangedSignal(signal);
@@ -97,11 +101,12 @@ class DBusRemoteObject {
   /// Throws [DBusUnknownInterfaceException] if introspection is not supported by this object.
   Future<DBusIntrospectNode> introspect() async {
     var result = await client.callMethod(
-        destination: name,
-        path: path,
-        interface: 'org.freedesktop.DBus.Introspectable',
-        name: 'Introspect',
-        replySignature: DBusSignature('s'));
+      destination: name,
+      path: path,
+      interface: 'org.freedesktop.DBus.Introspectable',
+      name: 'Introspect',
+      replySignature: DBusSignature('s'),
+    );
     var xml = result.returnValues[0].asString();
     return parseDBusIntrospectXml(xml);
   }
@@ -117,15 +122,19 @@ class DBusRemoteObject {
   /// Throws [DBusUnknownInterfaceException] if properties are not supported by this object.
   /// Throws [DBusUnknownPropertyException] if the property doesn't exist.
   /// Throws [DBusPropertyWriteOnlyException] if the property can't be read.
-  Future<DBusValue> getProperty(String interface, String name,
-      {DBusSignature? signature}) async {
+  Future<DBusValue> getProperty(
+    String interface,
+    String name, {
+    DBusSignature? signature,
+  }) async {
     var result = await client.callMethod(
-        destination: this.name,
-        path: path,
-        interface: 'org.freedesktop.DBus.Properties',
-        name: 'Get',
-        values: [DBusString(interface), DBusString(name)],
-        replySignature: DBusSignature('v'));
+      destination: this.name,
+      path: path,
+      interface: 'org.freedesktop.DBus.Properties',
+      name: 'Get',
+      values: [DBusString(interface), DBusString(name)],
+      replySignature: DBusSignature('v'),
+    );
     var value = result.returnValues[0].asVariant();
     if (signature != null && value.signature != signature) {
       throw DBusPropertySignatureException('$interface.$name', value);
@@ -140,12 +149,13 @@ class DBusRemoteObject {
   /// Throws [DBusUnknownInterfaceException] if properties are not supported by this object.
   Future<Map<String, DBusValue>> getAllProperties(String interface) async {
     var result = await client.callMethod(
-        destination: name,
-        path: path,
-        interface: 'org.freedesktop.DBus.Properties',
-        name: 'GetAll',
-        values: [DBusString(interface)],
-        replySignature: DBusSignature('a{sv}'));
+      destination: name,
+      path: path,
+      interface: 'org.freedesktop.DBus.Properties',
+      name: 'GetAll',
+      values: [DBusString(interface)],
+      replySignature: DBusSignature('a{sv}'),
+    );
     return result.returnValues[0].asStringVariantDict();
   }
 
@@ -157,14 +167,18 @@ class DBusRemoteObject {
   /// Throws [DBusUnknownPropertyException] if the property doesn't exist.
   /// Throws [DBusPropertyReadOnlyException] if the property can't be written.
   Future<void> setProperty(
-      String interface, String name, DBusValue value) async {
+    String interface,
+    String name,
+    DBusValue value,
+  ) async {
     await client.callMethod(
-        destination: this.name,
-        path: path,
-        interface: 'org.freedesktop.DBus.Properties',
-        name: 'Set',
-        values: [DBusString(interface), DBusString(name), DBusVariant(value)],
-        replySignature: DBusSignature(''));
+      destination: this.name,
+      path: path,
+      interface: 'org.freedesktop.DBus.Properties',
+      name: 'Set',
+      values: [DBusString(interface), DBusString(name), DBusVariant(value)],
+      replySignature: DBusSignature(''),
+    );
   }
 
   /// Invokes a method on this object.
@@ -180,21 +194,25 @@ class DBusRemoteObject {
   /// Throws [DBusUnknownMethodException] if the method with [name] is not available.
   /// Throws [DBusInvalidArgsException] if [args] aren't correct.
   Future<DBusMethodSuccessResponse> callMethod(
-      String? interface, String name, Iterable<DBusValue> values,
-      {DBusSignature? replySignature,
-      bool noReplyExpected = false,
-      bool noAutoStart = false,
-      bool allowInteractiveAuthorization = false}) async {
+    String? interface,
+    String name,
+    Iterable<DBusValue> values, {
+    DBusSignature? replySignature,
+    bool noReplyExpected = false,
+    bool noAutoStart = false,
+    bool allowInteractiveAuthorization = false,
+  }) async {
     return client.callMethod(
-        destination: this.name,
-        path: path,
-        interface: interface,
-        name: name,
-        values: values,
-        replySignature: replySignature,
-        noReplyExpected: noReplyExpected,
-        noAutoStart: noAutoStart,
-        allowInteractiveAuthorization: allowInteractiveAuthorization);
+      destination: this.name,
+      path: path,
+      interface: interface,
+      name: name,
+      values: values,
+      replySignature: replySignature,
+      noReplyExpected: noReplyExpected,
+      noAutoStart: noAutoStart,
+      allowInteractiveAuthorization: allowInteractiveAuthorization,
+    );
   }
 
   @override

--- a/lib/src/dbus_remote_object_manager.dart
+++ b/lib/src/dbus_remote_object_manager.dart
@@ -15,12 +15,13 @@ class DBusObjectManagerInterfacesAddedSignal extends DBusSignal {
       _decodeInterfacesAndProperties(values[1]);
 
   DBusObjectManagerInterfacesAddedSignal(DBusSignal signal)
-      : super(
-            sender: signal.sender,
-            path: signal.path,
-            interface: signal.interface,
-            name: signal.name,
-            values: signal.values);
+    : super(
+        sender: signal.sender,
+        path: signal.path,
+        interface: signal.interface,
+        name: signal.name,
+        values: signal.values,
+      );
 }
 
 /// Signal received when interfaces are removed.
@@ -32,12 +33,13 @@ class DBusObjectManagerInterfacesRemovedSignal extends DBusSignal {
   List<String> get interfaces => values[1].asStringArray().toList();
 
   DBusObjectManagerInterfacesRemovedSignal(DBusSignal signal)
-      : super(
-            sender: signal.sender,
-            path: signal.path,
-            interface: signal.interface,
-            name: signal.name,
-            values: signal.values);
+    : super(
+        sender: signal.sender,
+        path: signal.path,
+        interface: signal.interface,
+        name: signal.name,
+        values: signal.values,
+      );
 }
 
 /// An object to simplify access to a D-Bus object manager.
@@ -49,16 +51,21 @@ class DBusRemoteObjectManager extends DBusRemoteObject {
 
   /// Creates an object that access accesses a remote D-Bus object manager using bus [name] with [path].
   /// Requires the remote object to implement the org.freedesktop.DBus.ObjectManager interface.
-  DBusRemoteObjectManager(DBusClient client,
-      {required String name, required DBusObjectPath path})
-      : super(client, name: name, path: path) {
+  DBusRemoteObjectManager(
+    DBusClient client, {
+    required String name,
+    required DBusObjectPath path,
+  }) : super(client, name: name, path: path) {
     // Only add path_namespace if it's non-'/'. This removes a no-op key from
     // the match rule, and also works around a D-Bus bug where
     // path_namespace='/' matches nothing.
     // https://github.com/bus1/dbus-broker/issues/309
     var pathNamespace = path.value != '/' ? path : null;
-    var rawSignals =
-        DBusSignalStream(client, sender: name, pathNamespace: pathNamespace);
+    var rawSignals = DBusSignalStream(
+      client,
+      sender: name,
+      pathNamespace: pathNamespace,
+    );
     signals = rawSignals.map((signal) {
       if (signal.interface == 'org.freedesktop.DBus.ObjectManager' &&
           signal.name == 'InterfacesAdded' &&
@@ -81,18 +88,22 @@ class DBusRemoteObjectManager extends DBusRemoteObject {
   /// Gets all the sub-tree of objects, interfaces and properties of this object.
   /// Requires the remote object to implement the org.freedesktop.DBus.ObjectManager interface.
   Future<Map<DBusObjectPath, Map<String, Map<String, DBusValue>>>>
-      getManagedObjects() async {
+  getManagedObjects() async {
     var result = await client.callMethod(
-        destination: name,
-        path: path,
-        interface: 'org.freedesktop.DBus.ObjectManager',
-        name: 'GetManagedObjects',
-        replySignature: DBusSignature('a{oa{sa{sv}}}'));
+      destination: name,
+      path: path,
+      interface: 'org.freedesktop.DBus.ObjectManager',
+      name: 'GetManagedObjects',
+      replySignature: DBusSignature('a{oa{sa{sv}}}'),
+    );
 
     Map<DBusObjectPath, Map<String, Map<String, DBusValue>>> decodeObjects(
-        DBusValue objects) {
-      return objects.asDict().map((key, value) =>
-          MapEntry(key.asObjectPath(), _decodeInterfacesAndProperties(value)));
+      DBusValue objects,
+    ) {
+      return objects.asDict().map(
+        (key, value) =>
+            MapEntry(key.asObjectPath(), _decodeInterfacesAndProperties(value)),
+      );
     }
 
     return decodeObjects(result.returnValues[0]);
@@ -106,7 +117,9 @@ class DBusRemoteObjectManager extends DBusRemoteObject {
 
 /// Decodes a value with signature 'a{sa{sv}}'.
 Map<String, Map<String, DBusValue>> _decodeInterfacesAndProperties(
-    DBusValue object) {
+  DBusValue object,
+) {
   return object.asDict().map(
-      (key, value) => MapEntry(key.asString(), value.asStringVariantDict()));
+    (key, value) => MapEntry(key.asString(), value.asStringVariantDict()),
+  );
 }

--- a/lib/src/dbus_server.dart
+++ b/lib/src/dbus_server.dart
@@ -31,24 +31,34 @@ enum DBusServerStartServiceResult { success, alreadyRunning, notFound }
 /// Server-only error responses.
 class _DBusServerErrorResponse extends DBusMethodErrorResponse {
   _DBusServerErrorResponse.serviceUnknown([String? message])
-      : super('org.freedesktop.DBus.Error.ServiceUnknown',
-            message != null ? [DBusString(message)] : []);
+    : super(
+        'org.freedesktop.DBus.Error.ServiceUnknown',
+        message != null ? [DBusString(message)] : [],
+      );
 
   _DBusServerErrorResponse.nameHasNoOwner([String? message])
-      : super('org.freedesktop.DBus.Error.NameHasNoOwner',
-            message != null ? [DBusString(message)] : []);
+    : super(
+        'org.freedesktop.DBus.Error.NameHasNoOwner',
+        message != null ? [DBusString(message)] : [],
+      );
 
   _DBusServerErrorResponse.matchRuleInvalid([String? message])
-      : super('org.freedesktop.DBus.Error.MatchRuleInvalid',
-            message != null ? [DBusString(message)] : []);
+    : super(
+        'org.freedesktop.DBus.Error.MatchRuleInvalid',
+        message != null ? [DBusString(message)] : [],
+      );
 
   _DBusServerErrorResponse.matchRuleNotFound([String? message])
-      : super('org.freedesktop.DBus.Error.MatchRuleNotFound',
-            message != null ? [DBusString(message)] : []);
+    : super(
+        'org.freedesktop.DBus.Error.MatchRuleNotFound',
+        message != null ? [DBusString(message)] : [],
+      );
 
   _DBusServerErrorResponse.notSupported([String? message])
-      : super('org.freedesktop.DBus.Error.NotSupported',
-            message != null ? [DBusString(message)] : []);
+    : super(
+        'org.freedesktop.DBus.Error.NotSupported',
+        message != null ? [DBusString(message)] : [],
+      );
 }
 
 /// A client connected to a D-Bus server.
@@ -78,9 +88,10 @@ class _DBusRemoteClient {
   final matchRules = <DBusMatchRule>[];
 
   _DBusRemoteClient(this.serverSocket, this._socket, this.uniqueName)
-      : _authServer = DBusAuthServer(serverSocket.uuid, unixFdSupported: true) {
-    _authServer.responses
-        .listen((message) => _socket.write(utf8.encode('$message\r\n')));
+    : _authServer = DBusAuthServer(serverSocket.uuid, unixFdSupported: true) {
+    _authServer.responses.listen(
+      (message) => _socket.write(utf8.encode('$message\r\n')),
+    );
     _socket.listen((event) {
       if (event == RawSocketEvent.read) {
         _readData();
@@ -106,11 +117,12 @@ class _DBusRemoteClient {
       }
 
       if (rule.match(
-          type: message.type,
-          sender: sender,
-          interface: message.interface,
-          member: message.member,
-          path: message.path)) {
+        type: message.type,
+        sender: sender,
+        interface: message.interface,
+        member: message.member,
+        path: message.path,
+      )) {
         return true;
       }
     }
@@ -123,8 +135,9 @@ class _DBusRemoteClient {
     buffer.writeMessage(message);
     var controlMessages = <SocketControlMessage>[];
     if (buffer.resourceHandles.isNotEmpty) {
-      controlMessages
-          .add(SocketControlMessage.fromHandles(buffer.resourceHandles));
+      controlMessages.add(
+        SocketControlMessage.fromHandles(buffer.resourceHandles),
+      );
     }
 
     _socket.sendMessage(controlMessages, buffer.data);
@@ -176,17 +189,19 @@ class _DBusRemoteClient {
     }
 
     // Ensure the sender field is set and is correct.
-    var m = DBusMessage(message.type,
-        flags: message.flags,
-        serial: message.serial,
-        path: message.path,
-        interface: message.interface,
-        member: message.member,
-        errorName: message.errorName,
-        replySerial: message.replySerial,
-        destination: message.destination,
-        sender: uniqueName,
-        values: message.values);
+    var m = DBusMessage(
+      message.type,
+      flags: message.flags,
+      serial: message.serial,
+      path: message.path,
+      interface: message.interface,
+      member: message.member,
+      errorName: message.errorName,
+      replySerial: message.replySerial,
+      destination: message.destination,
+      sender: uniqueName,
+      values: message.values,
+    );
     server._processMessage(this, m);
 
     return false;
@@ -217,12 +232,16 @@ class _DBusServerSocket {
   final _clients = <_DBusRemoteClient>[];
 
   _DBusServerSocket(this.server, this.socket, this.connectionId) {
-    socket.listen((clientSocket) {
-      var uniqueName = DBusBusName(':$connectionId.$_nextClientId');
-      _nextClientId++;
-      var client = _DBusRemoteClient(this, clientSocket, uniqueName);
-      _clients.add(client);
-    }, onError: (error) {}, onDone: () => socket.close());
+    socket.listen(
+      (clientSocket) {
+        var uniqueName = DBusBusName(':$connectionId.$_nextClientId');
+        _nextClientId++;
+        var client = _DBusRemoteClient(this, clientSocket, uniqueName);
+        _clients.add(client);
+      },
+      onError: (error) {},
+      onDone: () => socket.close(),
+    );
   }
 
   /// Handle a client disconnecting.
@@ -246,16 +265,19 @@ class _ServerMethodCall extends DBusMethodCall {
   final _DBusRemoteClient client;
 
   _ServerMethodCall(this.client, DBusMessage message)
-      : super(
-            sender: message.sender?.value,
-            interface: message.interface?.value,
-            name: message.member!.value,
-            values: message.values,
-            noReplyExpected:
-                message.flags.contains(DBusMessageFlag.noReplyExpected),
-            noAutoStart: message.flags.contains(DBusMessageFlag.noAutoStart),
-            allowInteractiveAuthorization: message.flags
-                .contains(DBusMessageFlag.allowInteractiveAuthorization));
+    : super(
+        sender: message.sender?.value,
+        interface: message.interface?.value,
+        name: message.member!.value,
+        values: message.values,
+        noReplyExpected: message.flags.contains(
+          DBusMessageFlag.noReplyExpected,
+        ),
+        noAutoStart: message.flags.contains(DBusMessageFlag.noAutoStart),
+        allowInteractiveAuthorization: message.flags.contains(
+          DBusMessageFlag.allowInteractiveAuthorization,
+        ),
+      );
 }
 
 /// An open request for a name.
@@ -270,7 +292,10 @@ class _DBusNameRequest {
   bool doNotQueue;
 
   _DBusNameRequest(
-      this.allowReplacement, this.replaceExisting, this.doNotQueue);
+    this.allowReplacement,
+    this.replaceExisting,
+    this.doNotQueue,
+  );
 }
 
 /// A queue of clients requesting a name.
@@ -289,8 +314,12 @@ class _DBusNameQueue {
   _DBusNameQueue(this.name);
 
   /// Add/update a request from [client] for this name.
-  void addRequest(_DBusRemoteClient client, bool allowReplacement,
-      bool replaceExisting, bool doNotQueue) {
+  void addRequest(
+    _DBusRemoteClient client,
+    bool allowReplacement,
+    bool replaceExisting,
+    bool doNotQueue,
+  ) {
     var currentOwner = owner;
 
     var request = requests[client];
@@ -316,7 +345,8 @@ class _DBusNameQueue {
 
     /// Purge any do not queue requests.
     requests.removeWhere(
-        (client, request) => client != owner && request.doNotQueue);
+      (client, request) => client != owner && request.doNotQueue,
+    );
   }
 
   /// Returns true if [client] has a request on this name.
@@ -388,18 +418,21 @@ class DBusServer {
   }
 
   /// Emits a signal from the D-Bus server.
-  void emitSignal(
-      {required DBusObjectPath path,
-      required String interface,
-      required String name,
-      Iterable<DBusValue> values = const []}) {
-    var message = DBusMessage(DBusMessageType.signal,
-        flags: {DBusMessageFlag.noReplyExpected},
-        serial: _nextSerial,
-        path: path,
-        interface: DBusInterfaceName(interface),
-        member: DBusMemberName(name),
-        values: values.toList());
+  void emitSignal({
+    required DBusObjectPath path,
+    required String interface,
+    required String name,
+    Iterable<DBusValue> values = const [],
+  }) {
+    var message = DBusMessage(
+      DBusMessageType.signal,
+      flags: {DBusMessageFlag.noReplyExpected},
+      serial: _nextSerial,
+      path: path,
+      interface: DBusInterfaceName(interface),
+      member: DBusMemberName(name),
+      values: values.toList(),
+    );
     _nextSerial++;
     for (var client in _clients) {
       client.sendMessage(message);
@@ -413,12 +446,17 @@ class DBusServer {
     var tmpdir = address.properties['tmpdir'];
     var abstract = address.properties['abstract'];
     var runtime = address.properties['runtime'];
-    if ([path, dir, tmpdir, abstract, runtime]
-            .map((v) => v != null ? 1 : 0)
-            .reduce((a, b) => a + b) !=
+    if ([
+          path,
+          dir,
+          tmpdir,
+          abstract,
+          runtime,
+        ].map((v) => v != null ? 1 : 0).reduce((a, b) => a + b) !=
         1) {
       throw FormatException(
-          'D-Bus Unix address requires one of path, dir, tmpdir, abstract or runtime');
+        'D-Bus Unix address requires one of path, dir, tmpdir, abstract or runtime',
+      );
     }
     if (runtime != null && runtime != 'yes') {
       throw FormatException("Runtime must only contain the value 'yes'");
@@ -428,9 +466,10 @@ class DBusServer {
       var chars =
           'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz1234567890';
       var random = Random();
-      var suffix =
-          List<String>.generate(8, (i) => chars[random.nextInt(chars.length)])
-              .join();
+      var suffix = List<String>.generate(
+        8,
+        (i) => chars[random.nextInt(chars.length)],
+      ).join();
       return '${dir.path}/dbus-$suffix';
     }
 
@@ -457,7 +496,9 @@ class DBusServer {
       }
     }
     await _addServerSocket(
-        InternetAddress(path, type: InternetAddressType.unix), 0);
+      InternetAddress(path, type: InternetAddressType.unix),
+      0,
+    );
     return DBusAddress.unix(path: path);
   }
 
@@ -511,16 +552,20 @@ class DBusServer {
       port = serverSocket.socket.port;
     }
     // Note the bind address is not provided, as the client doesn't need it for connecting.
-    return DBusAddress.tcp(host,
-        port: port,
-        family: {
-          InternetAddressType.IPv4: DBusAddressTcpFamily.ipv4,
-          InternetAddressType.IPv6: DBusAddressTcpFamily.ipv6
-        }[type]);
+    return DBusAddress.tcp(
+      host,
+      port: port,
+      family: {
+        InternetAddressType.IPv4: DBusAddressTcpFamily.ipv4,
+        InternetAddressType.IPv6: DBusAddressTcpFamily.ipv6,
+      }[type],
+    );
   }
 
   Future<_DBusServerSocket> _addServerSocket(
-      InternetAddress address, int port) async {
+    InternetAddress address,
+    int port,
+  ) async {
     var socket = await RawServerSocket.bind(address, port);
     var serverSocket = _DBusServerSocket(this, socket, _nextConnectionId);
     _sockets.add(serverSocket);
@@ -537,7 +582,9 @@ class DBusServer {
 
   /// Process an incoming message.
   Future<void> _processMessage(
-      _DBusRemoteClient? client, DBusMessage message) async {
+    _DBusRemoteClient? client,
+    DBusMessage message,
+  ) async {
     // Forward to any clients that are listening to this message.
     if (_messageBusObject != null) {
       var targetClient = message.destination != null
@@ -560,7 +607,8 @@ class DBusServer {
             message.member?.value == 'Hello')) {
       await client.close();
       response = DBusMethodErrorResponse.accessDenied(
-          'Client tried to send a message other than Hello without being registered');
+        'Client tried to send a message other than Hello without being registered',
+      );
     } else if (message.destination?.value == 'org.freedesktop.DBus') {
       if (client != null && message.type == DBusMessageType.methodCall) {
         response = await _processServerMethodCall(client, message);
@@ -570,7 +618,8 @@ class DBusServer {
       if (message.destination != null &&
           _messageBusObject?._getClientByName(message.destination!) == null) {
         response = _DBusServerErrorResponse.serviceUnknown(
-            'The name ${message.destination} is not registered');
+          'The name ${message.destination} is not registered',
+        );
       }
     }
 
@@ -587,14 +636,16 @@ class DBusServer {
         errorName = DBusErrorName(response.errorName);
         values = response.values;
       }
-      var responseMessage = DBusMessage(type,
-          flags: {DBusMessageFlag.noReplyExpected},
-          serial: _nextSerial,
-          errorName: errorName,
-          replySerial: message.serial,
-          destination: message.sender,
-          sender: DBusBusName('org.freedesktop.DBus'),
-          values: values);
+      var responseMessage = DBusMessage(
+        type,
+        flags: {DBusMessageFlag.noReplyExpected},
+        serial: _nextSerial,
+        errorName: errorName,
+        replySerial: message.serial,
+        destination: message.sender,
+        sender: DBusBusName('org.freedesktop.DBus'),
+        values: values,
+      );
       _nextSerial++;
 
       if (_messageBusObject != null) {
@@ -608,7 +659,9 @@ class DBusServer {
 
   /// Process a method call requested on the D-Bus server.
   Future<DBusMethodResponse> _processServerMethodCall(
-      _DBusRemoteClient client, DBusMessage message) async {
+    _DBusRemoteClient client,
+    DBusMessage message,
+  ) async {
     if (message.member == null) {
       return DBusMethodErrorResponse.failed();
     }
@@ -623,8 +676,9 @@ class DBusServer {
         objectTree.add(message.path ?? DBusObjectPath('/'), _messageBusObject!);
       }
       return handleIntrospectableMethodCall(
-          message.path != null ? objectTree.lookup(message.path!) : null,
-          methodCall);
+        message.path != null ? objectTree.lookup(message.path!) : null,
+        methodCall,
+      );
     } else if (_messageBusObject != null) {
       if (methodCall.interface == 'org.freedesktop.DBus.Properties') {
         return await handlePropertiesMethodCall(_messageBusObject!, methodCall);
@@ -638,17 +692,23 @@ class DBusServer {
 
   /// Emits a signal from the D-Bus server.
   void _emitSignal(
-      DBusObjectPath path, DBusInterfaceName interface, DBusMemberName name,
-      {DBusBusName? destination, Iterable<DBusValue> values = const []}) {
-    var message = DBusMessage(DBusMessageType.signal,
-        flags: {DBusMessageFlag.noReplyExpected},
-        serial: _nextSerial,
-        path: path,
-        interface: interface,
-        member: name,
-        destination: destination,
-        sender: DBusBusName('org.freedesktop.DBus'),
-        values: values.toList());
+    DBusObjectPath path,
+    DBusInterfaceName interface,
+    DBusMemberName name, {
+    DBusBusName? destination,
+    Iterable<DBusValue> values = const [],
+  }) {
+    var message = DBusMessage(
+      DBusMessageType.signal,
+      flags: {DBusMessageFlag.noReplyExpected},
+      serial: _nextSerial,
+      path: path,
+      interface: interface,
+      member: name,
+      destination: destination,
+      sender: DBusBusName('org.freedesktop.DBus'),
+      values: values.toList(),
+    );
     _nextSerial++;
     _processMessage(null, message);
   }
@@ -667,7 +727,7 @@ class _MessageBusObject extends DBusObject {
   final _nameQueues = <DBusBusName, _DBusNameQueue>{};
 
   _MessageBusObject(this.server)
-      : super(DBusObjectPath('/org/freedesktop/DBus'));
+    : super(DBusObjectPath('/org/freedesktop/DBus'));
 
   @override
   Future<DBusMethodResponse> handleMethodCall(DBusMethodCall methodCall) async {
@@ -686,7 +746,12 @@ class _MessageBusObject extends DBusObject {
           var replaceExisting = (flags & 0x02) != 0;
           var doNotQueue = (flags & 0x04) != 0;
           return _requestName(
-              client, name, allowReplacement, replaceExisting, doNotQueue);
+            client,
+            name,
+            allowReplacement,
+            replaceExisting,
+            doNotQueue,
+          );
         case 'ReleaseName':
           if (methodCall.signature != DBusSignature('s')) {
             return DBusMethodErrorResponse.invalidArgs();
@@ -765,34 +830,50 @@ class _MessageBusObject extends DBusObject {
           return _getId(client);
         default:
           return DBusMethodErrorResponse.unknownMethod(
-              'Method ${methodCall.interface}.${methodCall.name} not provided');
+            'Method ${methodCall.interface}.${methodCall.name} not provided',
+          );
       }
     } else {
       return DBusMethodErrorResponse.unknownInterface(
-          'Interface ${methodCall.interface} not provided');
+        'Interface ${methodCall.interface} not provided',
+      );
     }
   }
 
   @override
   Future<DBusMethodResponse> getProperty(
-      String interfaceName, String name) async {
+    String interfaceName,
+    String name,
+  ) async {
     if (interfaceName == 'org.freedesktop.DBus') {
       switch (name) {
         case 'Features':
-          return DBusGetPropertyResponse(DBusArray(DBusSignature('s'),
-              server._features.map((value) => DBusString(value))));
+          return DBusGetPropertyResponse(
+            DBusArray(
+              DBusSignature('s'),
+              server._features.map((value) => DBusString(value)),
+            ),
+          );
         case 'Interfaces':
-          return DBusGetPropertyResponse(DBusArray(DBusSignature('s'),
-              server._interfaces.map((value) => DBusString(value))));
+          return DBusGetPropertyResponse(
+            DBusArray(
+              DBusSignature('s'),
+              server._interfaces.map((value) => DBusString(value)),
+            ),
+          );
       }
     }
     return DBusMethodErrorResponse.unknownProperty(
-        'Properies $interfaceName.$name does not exist');
+      'Properies $interfaceName.$name does not exist',
+    );
   }
 
   @override
   Future<DBusMethodResponse> setProperty(
-      String interfaceName, String name, DBusValue value) async {
+    String interfaceName,
+    String name,
+    DBusValue value,
+  ) async {
     if (interfaceName == 'org.freedesktop.DBus') {
       switch (name) {
         case 'Features':
@@ -801,17 +882,22 @@ class _MessageBusObject extends DBusObject {
       }
     }
     return DBusMethodErrorResponse.unknownProperty(
-        'Properies $interfaceName.$name does not exist');
+      'Properies $interfaceName.$name does not exist',
+    );
   }
 
   @override
   Future<DBusMethodResponse> getAllProperties(String interfaceName) async {
     var properties = <String, DBusValue>{};
     if (interfaceName == 'org.freedesktop.DBus') {
-      properties['Features'] = DBusArray(DBusSignature('s'),
-          server._features.map((value) => DBusString(value)));
-      properties['Interfaces'] = DBusArray(DBusSignature('s'),
-          server._interfaces.map((value) => DBusString(value)));
+      properties['Features'] = DBusArray(
+        DBusSignature('s'),
+        server._features.map((value) => DBusString(value)),
+      );
+      properties['Interfaces'] = DBusArray(
+        DBusSignature('s'),
+        server._interfaces.map((value) => DBusString(value)),
+      );
     }
     return DBusGetAllPropertiesResponse(properties);
   }
@@ -819,113 +905,270 @@ class _MessageBusObject extends DBusObject {
   @override
   List<DBusIntrospectInterface> introspect() {
     return [
-      DBusIntrospectInterface('org.freedesktop.DBus', methods: [
-        DBusIntrospectMethod('Hello', args: [
-          DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.out,
-              name: 'unique_name')
-        ]),
-        DBusIntrospectMethod('RequestName', args: [
-          DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.in_,
-              name: 'name'),
-          DBusIntrospectArgument(DBusSignature('u'), DBusArgumentDirection.in_,
-              name: 'flags'),
-          DBusIntrospectArgument(DBusSignature('u'), DBusArgumentDirection.out,
-              name: 'result')
-        ]),
-        DBusIntrospectMethod('ReleaseName', args: [
-          DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.in_,
-              name: 'name'),
-          DBusIntrospectArgument(DBusSignature('u'), DBusArgumentDirection.out,
-              name: 'result')
-        ]),
-        DBusIntrospectMethod('ListQueuedOwners', args: [
-          DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.in_,
-              name: 'name'),
-          DBusIntrospectArgument(DBusSignature('as'), DBusArgumentDirection.out,
-              name: 'names')
-        ]),
-        DBusIntrospectMethod('ListNames', args: [
-          DBusIntrospectArgument(DBusSignature('as'), DBusArgumentDirection.out,
-              name: 'names')
-        ]),
-        DBusIntrospectMethod('ListActivatableNames', args: [
-          DBusIntrospectArgument(DBusSignature('as'), DBusArgumentDirection.out,
-              name: 'names')
-        ]),
-        DBusIntrospectMethod('NameHasOwner', args: [
-          DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.in_,
-              name: 'name'),
-          DBusIntrospectArgument(DBusSignature('b'), DBusArgumentDirection.out,
-              name: 'result')
-        ]),
-        DBusIntrospectMethod('StartServiceByName', args: [
-          DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.in_,
-              name: 'name'),
-          DBusIntrospectArgument(DBusSignature('u'), DBusArgumentDirection.in_,
-              name: 'flags'),
-          DBusIntrospectArgument(DBusSignature('u'), DBusArgumentDirection.out,
-              name: 'result')
-        ]),
-        DBusIntrospectMethod('GetNameOwner', args: [
-          DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.in_,
-              name: 'name'),
-          DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.out,
-              name: 'owner')
-        ]),
-        DBusIntrospectMethod('GetConnectionUnixUser', args: [
-          DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.in_,
-              name: 'name'),
-          DBusIntrospectArgument(DBusSignature('u'), DBusArgumentDirection.out,
-              name: 'unix_user_id')
-        ]),
-        DBusIntrospectMethod('GetConnectionUnixProcessID', args: [
-          DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.in_,
-              name: 'name'),
-          DBusIntrospectArgument(DBusSignature('u'), DBusArgumentDirection.out,
-              name: 'unix_process_id')
-        ]),
-        DBusIntrospectMethod('GetConnectionCredentials', args: [
-          DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.in_,
-              name: 'name'),
-          DBusIntrospectArgument(
-              DBusSignature('a{sv}'), DBusArgumentDirection.out,
-              name: 'credentials')
-        ]),
-        DBusIntrospectMethod('AddMatch', args: [
-          DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.in_,
-              name: 'rule')
-        ]),
-        DBusIntrospectMethod('RemoveMatch', args: [
-          DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.in_,
-              name: 'rule')
-        ]),
-        DBusIntrospectMethod('GetId', args: [
-          DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.out,
-              name: 'id')
-        ])
-      ], signals: [
-        DBusIntrospectSignal('NameOwnerChanged', args: [
-          DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.out,
-              name: 'name'),
-          DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.out,
-              name: 'old_owner'),
-          DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.out,
-              name: 'new_owner')
-        ]),
-        DBusIntrospectSignal('NameLost', args: [
-          DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.out,
-              name: 'name'),
-        ]),
-        DBusIntrospectSignal('NameAcquired', args: [
-          DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.out,
-              name: 'name'),
-        ])
-      ], properties: [
-        DBusIntrospectProperty('Features', DBusSignature('as'),
-            access: DBusPropertyAccess.read),
-        DBusIntrospectProperty('Interfaces', DBusSignature('as'),
-            access: DBusPropertyAccess.read)
-      ])
+      DBusIntrospectInterface(
+        'org.freedesktop.DBus',
+        methods: [
+          DBusIntrospectMethod(
+            'Hello',
+            args: [
+              DBusIntrospectArgument(
+                DBusSignature('s'),
+                DBusArgumentDirection.out,
+                name: 'unique_name',
+              ),
+            ],
+          ),
+          DBusIntrospectMethod(
+            'RequestName',
+            args: [
+              DBusIntrospectArgument(
+                DBusSignature('s'),
+                DBusArgumentDirection.in_,
+                name: 'name',
+              ),
+              DBusIntrospectArgument(
+                DBusSignature('u'),
+                DBusArgumentDirection.in_,
+                name: 'flags',
+              ),
+              DBusIntrospectArgument(
+                DBusSignature('u'),
+                DBusArgumentDirection.out,
+                name: 'result',
+              ),
+            ],
+          ),
+          DBusIntrospectMethod(
+            'ReleaseName',
+            args: [
+              DBusIntrospectArgument(
+                DBusSignature('s'),
+                DBusArgumentDirection.in_,
+                name: 'name',
+              ),
+              DBusIntrospectArgument(
+                DBusSignature('u'),
+                DBusArgumentDirection.out,
+                name: 'result',
+              ),
+            ],
+          ),
+          DBusIntrospectMethod(
+            'ListQueuedOwners',
+            args: [
+              DBusIntrospectArgument(
+                DBusSignature('s'),
+                DBusArgumentDirection.in_,
+                name: 'name',
+              ),
+              DBusIntrospectArgument(
+                DBusSignature('as'),
+                DBusArgumentDirection.out,
+                name: 'names',
+              ),
+            ],
+          ),
+          DBusIntrospectMethod(
+            'ListNames',
+            args: [
+              DBusIntrospectArgument(
+                DBusSignature('as'),
+                DBusArgumentDirection.out,
+                name: 'names',
+              ),
+            ],
+          ),
+          DBusIntrospectMethod(
+            'ListActivatableNames',
+            args: [
+              DBusIntrospectArgument(
+                DBusSignature('as'),
+                DBusArgumentDirection.out,
+                name: 'names',
+              ),
+            ],
+          ),
+          DBusIntrospectMethod(
+            'NameHasOwner',
+            args: [
+              DBusIntrospectArgument(
+                DBusSignature('s'),
+                DBusArgumentDirection.in_,
+                name: 'name',
+              ),
+              DBusIntrospectArgument(
+                DBusSignature('b'),
+                DBusArgumentDirection.out,
+                name: 'result',
+              ),
+            ],
+          ),
+          DBusIntrospectMethod(
+            'StartServiceByName',
+            args: [
+              DBusIntrospectArgument(
+                DBusSignature('s'),
+                DBusArgumentDirection.in_,
+                name: 'name',
+              ),
+              DBusIntrospectArgument(
+                DBusSignature('u'),
+                DBusArgumentDirection.in_,
+                name: 'flags',
+              ),
+              DBusIntrospectArgument(
+                DBusSignature('u'),
+                DBusArgumentDirection.out,
+                name: 'result',
+              ),
+            ],
+          ),
+          DBusIntrospectMethod(
+            'GetNameOwner',
+            args: [
+              DBusIntrospectArgument(
+                DBusSignature('s'),
+                DBusArgumentDirection.in_,
+                name: 'name',
+              ),
+              DBusIntrospectArgument(
+                DBusSignature('s'),
+                DBusArgumentDirection.out,
+                name: 'owner',
+              ),
+            ],
+          ),
+          DBusIntrospectMethod(
+            'GetConnectionUnixUser',
+            args: [
+              DBusIntrospectArgument(
+                DBusSignature('s'),
+                DBusArgumentDirection.in_,
+                name: 'name',
+              ),
+              DBusIntrospectArgument(
+                DBusSignature('u'),
+                DBusArgumentDirection.out,
+                name: 'unix_user_id',
+              ),
+            ],
+          ),
+          DBusIntrospectMethod(
+            'GetConnectionUnixProcessID',
+            args: [
+              DBusIntrospectArgument(
+                DBusSignature('s'),
+                DBusArgumentDirection.in_,
+                name: 'name',
+              ),
+              DBusIntrospectArgument(
+                DBusSignature('u'),
+                DBusArgumentDirection.out,
+                name: 'unix_process_id',
+              ),
+            ],
+          ),
+          DBusIntrospectMethod(
+            'GetConnectionCredentials',
+            args: [
+              DBusIntrospectArgument(
+                DBusSignature('s'),
+                DBusArgumentDirection.in_,
+                name: 'name',
+              ),
+              DBusIntrospectArgument(
+                DBusSignature('a{sv}'),
+                DBusArgumentDirection.out,
+                name: 'credentials',
+              ),
+            ],
+          ),
+          DBusIntrospectMethod(
+            'AddMatch',
+            args: [
+              DBusIntrospectArgument(
+                DBusSignature('s'),
+                DBusArgumentDirection.in_,
+                name: 'rule',
+              ),
+            ],
+          ),
+          DBusIntrospectMethod(
+            'RemoveMatch',
+            args: [
+              DBusIntrospectArgument(
+                DBusSignature('s'),
+                DBusArgumentDirection.in_,
+                name: 'rule',
+              ),
+            ],
+          ),
+          DBusIntrospectMethod(
+            'GetId',
+            args: [
+              DBusIntrospectArgument(
+                DBusSignature('s'),
+                DBusArgumentDirection.out,
+                name: 'id',
+              ),
+            ],
+          ),
+        ],
+        signals: [
+          DBusIntrospectSignal(
+            'NameOwnerChanged',
+            args: [
+              DBusIntrospectArgument(
+                DBusSignature('s'),
+                DBusArgumentDirection.out,
+                name: 'name',
+              ),
+              DBusIntrospectArgument(
+                DBusSignature('s'),
+                DBusArgumentDirection.out,
+                name: 'old_owner',
+              ),
+              DBusIntrospectArgument(
+                DBusSignature('s'),
+                DBusArgumentDirection.out,
+                name: 'new_owner',
+              ),
+            ],
+          ),
+          DBusIntrospectSignal(
+            'NameLost',
+            args: [
+              DBusIntrospectArgument(
+                DBusSignature('s'),
+                DBusArgumentDirection.out,
+                name: 'name',
+              ),
+            ],
+          ),
+          DBusIntrospectSignal(
+            'NameAcquired',
+            args: [
+              DBusIntrospectArgument(
+                DBusSignature('s'),
+                DBusArgumentDirection.out,
+                name: 'name',
+              ),
+            ],
+          ),
+        ],
+        properties: [
+          DBusIntrospectProperty(
+            'Features',
+            DBusSignature('as'),
+            access: DBusPropertyAccess.read,
+          ),
+          DBusIntrospectProperty(
+            'Interfaces',
+            DBusSignature('as'),
+            access: DBusPropertyAccess.read,
+          ),
+        ],
+      ),
     ];
   }
 
@@ -950,8 +1193,13 @@ class _MessageBusObject extends DBusObject {
   }
 
   // Implementation of org.freedesktop.DBus.RequestName
-  DBusMethodResponse _requestName(_DBusRemoteClient client, String name,
-      bool allowReplacement, bool replaceExisting, bool doNotQueue) {
+  DBusMethodResponse _requestName(
+    _DBusRemoteClient client,
+    String name,
+    bool allowReplacement,
+    bool replaceExisting,
+    bool doNotQueue,
+  ) {
     DBusBusName name_;
     try {
       name_ = DBusBusName(name);
@@ -960,7 +1208,8 @@ class _MessageBusObject extends DBusObject {
     }
     if (name_.isUnique) {
       return DBusMethodErrorResponse.invalidArgs(
-          'Not allowed to request a unique bus name');
+        'Not allowed to request a unique bus name',
+      );
     }
 
     var queue = _nameQueues[name_];
@@ -999,7 +1248,8 @@ class _MessageBusObject extends DBusObject {
     }
     if (name_.isUnique) {
       return DBusMethodErrorResponse.invalidArgs(
-          'Not allowed to release a unique bus name');
+        'Not allowed to release a unique bus name',
+      );
     }
 
     var queue = _nameQueues[name_];
@@ -1074,8 +1324,9 @@ class _MessageBusObject extends DBusObject {
     }
     var queue = _nameQueues[name_];
     var names = queue != null
-        ? queue.requests.keys
-            .map((client) => DBusString(client.uniqueName.value))
+        ? queue.requests.keys.map(
+            (client) => DBusString(client.uniqueName.value),
+          )
         : <DBusString>[];
     return DBusMethodSuccessResponse([DBusArray(DBusSignature('s'), names)]);
   }
@@ -1084,7 +1335,8 @@ class _MessageBusObject extends DBusObject {
   DBusMethodResponse _listNames() {
     var names = <DBusValue>[DBusString('org.freedesktop.DBus')];
     names.addAll(
-        server._clients.map((client) => DBusString(client.uniqueName.value)));
+      server._clients.map((client) => DBusString(client.uniqueName.value)),
+    );
     names.addAll(_nameQueues.keys.map((name) => DBusString(name.value)));
     return DBusMethodSuccessResponse([DBusArray(DBusSignature('s'), names)]);
   }
@@ -1093,9 +1345,11 @@ class _MessageBusObject extends DBusObject {
   DBusMethodResponse _listActivatableNames() {
     return DBusMethodSuccessResponse([
       DBusArray(
-          DBusSignature('s'),
-          (['org.freedesktop.DBus'] + server.activatableNames)
-              .map((name) => DBusString(name)))
+        DBusSignature('s'),
+        (['org.freedesktop.DBus'] + server.activatableNames).map(
+          (name) => DBusString(name),
+        ),
+      ),
     ]);
   }
 
@@ -1175,14 +1429,16 @@ class _MessageBusObject extends DBusObject {
         name_ = DBusBusName(name);
       } on FormatException {
         return DBusMethodErrorResponse.invalidArgs(
-            "Bus name '$name' not valid");
+          "Bus name '$name' not valid",
+        );
       }
       var client = _getClientByName(name_);
       if (client == null) {
         return _DBusServerErrorResponse.nameHasNoOwner('Name $name not owned');
       }
       return _DBusServerErrorResponse.notSupported(
-          "Can't determine client credentials");
+        "Can't determine client credentials",
+      );
     }
 
     return DBusMethodSuccessResponse([DBusUint32(uid)]);
@@ -1199,14 +1455,16 @@ class _MessageBusObject extends DBusObject {
         name_ = DBusBusName(name);
       } on FormatException {
         return DBusMethodErrorResponse.invalidArgs(
-            "Bus name '$name' not valid");
+          "Bus name '$name' not valid",
+        );
       }
       var client = _getClientByName(name_);
       if (client == null) {
         return _DBusServerErrorResponse.nameHasNoOwner('Name $name not owned');
       }
       return _DBusServerErrorResponse.notSupported(
-          "Can't determine client credentials");
+        "Can't determine client credentials",
+      );
     }
 
     return DBusMethodSuccessResponse([DBusUint32(clientPid)]);
@@ -1224,7 +1482,8 @@ class _MessageBusObject extends DBusObject {
         name_ = DBusBusName(name);
       } on FormatException {
         return DBusMethodErrorResponse.invalidArgs(
-            "Bus name '$name' not valid");
+          "Bus name '$name' not valid",
+        );
       }
       var client = _getClientByName(name_);
       if (client == null) {
@@ -1232,15 +1491,18 @@ class _MessageBusObject extends DBusObject {
       }
 
       return _DBusServerErrorResponse.notSupported(
-          "Can't determine client credentials");
+        "Can't determine client credentials",
+      );
     }
 
     return DBusMethodSuccessResponse([
       DBusDict(
-          DBusSignature('s'),
-          DBusSignature('v'),
-          credentials.map(
-              (key, value) => MapEntry(DBusString(key), DBusVariant(value))))
+        DBusSignature('s'),
+        DBusSignature('v'),
+        credentials.map(
+          (key, value) => MapEntry(DBusString(key), DBusVariant(value)),
+        ),
+      ),
     ]);
   }
 
@@ -1277,32 +1539,41 @@ class _MessageBusObject extends DBusObject {
 
   /// Emits org.freedesktop.DBus.NameOwnerChanged.
   void _emitNameOwnerChanged(
-      DBusBusName name, DBusBusName? oldOwner, DBusBusName? newOwner) {
+    DBusBusName name,
+    DBusBusName? oldOwner,
+    DBusBusName? newOwner,
+  ) {
     server._emitSignal(
-        DBusObjectPath('/org/freedesktop/DBus'),
-        DBusInterfaceName('org.freedesktop.DBus'),
-        DBusMemberName('NameOwnerChanged'),
-        values: [
-          DBusString(name.value),
-          DBusString(oldOwner?.value ?? ''),
-          DBusString(newOwner?.value ?? '')
-        ]);
+      DBusObjectPath('/org/freedesktop/DBus'),
+      DBusInterfaceName('org.freedesktop.DBus'),
+      DBusMemberName('NameOwnerChanged'),
+      values: [
+        DBusString(name.value),
+        DBusString(oldOwner?.value ?? ''),
+        DBusString(newOwner?.value ?? ''),
+      ],
+    );
   }
 
   /// Emits org.freedesktop.DBus.NameAcquired.
   void _emitNameAcquired(DBusBusName destination, DBusBusName name) {
     server._emitSignal(
-        DBusObjectPath('/org/freedesktop/DBus'),
-        DBusInterfaceName('org.freedesktop.DBus'),
-        DBusMemberName('NameAcquired'),
-        values: [DBusString(name.value)],
-        destination: destination);
+      DBusObjectPath('/org/freedesktop/DBus'),
+      DBusInterfaceName('org.freedesktop.DBus'),
+      DBusMemberName('NameAcquired'),
+      values: [DBusString(name.value)],
+      destination: destination,
+    );
   }
 
   /// Emits org.freedesktop.DBus.NameLost.
   void _emitNameLost(DBusBusName destination, DBusBusName name) {
-    server._emitSignal(DBusObjectPath('/org/freedesktop/DBus'),
-        DBusInterfaceName('org.freedesktop.DBus'), DBusMemberName('NameLost'),
-        values: [DBusString(name.value)], destination: destination);
+    server._emitSignal(
+      DBusObjectPath('/org/freedesktop/DBus'),
+      DBusInterfaceName('org.freedesktop.DBus'),
+      DBusMemberName('NameLost'),
+      values: [DBusString(name.value)],
+      destination: destination,
+    );
   }
 }

--- a/lib/src/dbus_signal.dart
+++ b/lib/src/dbus_signal.dart
@@ -22,12 +22,13 @@ class DBusSignal {
       .map((value) => value.signature)
       .fold(DBusSignature(''), (a, b) => a + b);
 
-  const DBusSignal(
-      {required this.sender,
-      required this.path,
-      required this.interface,
-      required this.name,
-      this.values = const []});
+  const DBusSignal({
+    required this.sender,
+    required this.path,
+    required this.interface,
+    required this.name,
+    this.values = const [],
+  });
 
   @override
   bool operator ==(other) =>

--- a/lib/src/dbus_uuid.dart
+++ b/lib/src/dbus_uuid.dart
@@ -7,8 +7,11 @@ class DBusUUID {
   /// Creates a new random UUID.
   DBusUUID() {
     var random = Random();
-    value =
-        List<int>.generate(16, (index) => random.nextInt(256), growable: false);
+    value = List<int>.generate(
+      16,
+      (index) => random.nextInt(256),
+      growable: false,
+    );
   }
 
   /// Creates a new UUID from a hexadecimal encoded string.
@@ -17,10 +20,11 @@ class DBusUUID {
       throw FormatException('Invalid UUID');
     }
     this.value = List<int>.generate(
-        16,
-        (index) =>
-            int.parse(value.substring(index * 2, index * 2 + 2), radix: 16),
-        growable: false);
+      16,
+      (index) =>
+          int.parse(value.substring(index * 2, index * 2 + 2), radix: 16),
+      growable: false,
+    );
   }
 
   /// Converts the UUID into a hexadecimal encoded string.

--- a/lib/src/dbus_value.dart
+++ b/lib/src/dbus_value.dart
@@ -148,7 +148,7 @@ class DBusByte extends DBusValue {
 
   /// Creates a new byte with the given [value].
   const DBusByte(this.value)
-      : assert(value >= 0 && value <= 255, 'Byte must be in range [0, 255]');
+    : assert(value >= 0 && value <= 255, 'Byte must be in range [0, 255]');
 
   @override
   DBusSignature get signature {
@@ -205,8 +205,10 @@ class DBusInt16 extends DBusValue {
 
   /// Creates a new signed 16 bit integer with the given [value].
   const DBusInt16(this.value)
-      : assert(value >= -32768 && value <= 32767,
-            'Int16 must be in range [-32768, 32767]');
+    : assert(
+        value >= -32768 && value <= 32767,
+        'Int16 must be in range [-32768, 32767]',
+      );
 
   @override
   DBusSignature get signature {
@@ -235,8 +237,10 @@ class DBusUint16 extends DBusValue {
 
   /// Creates a new unsigned 16 bit integer with the given [value].
   const DBusUint16(this.value)
-      : assert(
-            value >= 0 && value <= 65535, 'Uint16 must be in range [0, 65535]');
+    : assert(
+        value >= 0 && value <= 65535,
+        'Uint16 must be in range [0, 65535]',
+      );
 
   @override
   DBusSignature get signature {
@@ -265,8 +269,10 @@ class DBusInt32 extends DBusValue {
 
   /// Creates a new signed 32 bit integer with the given [value].
   const DBusInt32(this.value)
-      : assert(value >= -2147483648 && value <= 2147483647,
-            'Int32 must be in range [-2147483648, 2147483647]');
+    : assert(
+        value >= -2147483648 && value <= 2147483647,
+        'Int32 must be in range [-2147483648, 2147483647]',
+      );
 
   @override
   DBusSignature get signature {
@@ -295,8 +301,10 @@ class DBusUint32 extends DBusValue {
 
   /// Creates a new unsigned 32 bit integer with the given [value].
   const DBusUint32(this.value)
-      : assert(value >= 0 && value <= 4294967295,
-            'Uint32 must be in range [0, 4294967295]');
+    : assert(
+        value >= 0 && value <= 4294967295,
+        'Uint32 must be in range [0, 4294967295]',
+      );
 
   @override
   DBusSignature get signature {
@@ -325,8 +333,10 @@ class DBusInt64 extends DBusValue {
 
   /// Creates a new signed 64 bit integer with the given [value].
   const DBusInt64(this.value)
-      : assert(value >= -(1 << 63) && value <= (1 << 63) - 1,
-            'Int64 must be in range [-9223372036854775808, 9223372036854775807]');
+    : assert(
+        value >= -(1 << 63) && value <= (1 << 63) - 1,
+        'Int64 must be in range [-9223372036854775808, 9223372036854775807]',
+      );
 
   @override
   DBusSignature get signature {
@@ -538,7 +548,10 @@ class DBusSignature extends DBusValue {
   DBusSignature(this.value) {
     if (value.length > 255) {
       throw ArgumentError.value(
-          value, 'value', 'Signature maximum length is 255 characters');
+        value,
+        'value',
+        'Signature maximum length is 255 characters',
+      );
     }
     var index = 0;
     while (index < value.length) {
@@ -634,7 +647,10 @@ class DBusSignature extends DBusValue {
       var end = _findClosing(value, index, '(', ')');
       if (end < 0) {
         throw ArgumentError.value(
-            value, 'value', 'Struct missing closing parenthesis');
+          value,
+          'value',
+          'Struct missing closing parenthesis',
+        );
       }
       var childIndex = index + 1;
       while (childIndex < end) {
@@ -654,8 +670,11 @@ class DBusSignature extends DBusValue {
         childCount++;
       }
       if (childCount != 2) {
-        throw ArgumentError.value(value, 'value',
-            "Dict doesn't have correct number of child signatures");
+        throw ArgumentError.value(
+          value,
+          'value',
+          "Dict doesn't have correct number of child signatures",
+        );
       }
       return end;
     } else if (value.startsWith('a', index)) {
@@ -674,7 +693,10 @@ class DBusSignature extends DBusValue {
       return index;
     } else {
       throw ArgumentError.value(
-          value, 'value', 'Signature contains unknown characters');
+        value,
+        'value',
+        'Signature contains unknown characters',
+      );
     }
   }
 
@@ -775,13 +797,19 @@ class DBusMaybe extends DBusValue {
   /// Creates a new D-Bus maybe containing [value].
   DBusMaybe(this.valueSignature, this.value) {
     if (!valueSignature.isSingleCompleteType) {
-      throw ArgumentError.value(valueSignature, 'valueSignature',
-          'Maybe value type must be a single complete type');
+      throw ArgumentError.value(
+        valueSignature,
+        'valueSignature',
+        'Maybe value type must be a single complete type',
+      );
     }
 
     if (value != null && value!.signature.value != valueSignature.value) {
       throw ArgumentError.value(
-          value, 'value', "Value doesn't match signature $valueSignature");
+        value,
+        'value',
+        "Value doesn't match signature $valueSignature",
+      );
     }
   }
 
@@ -890,16 +918,22 @@ class DBusArray extends DBusValue {
   /// [childSignature] must contain a single type.
   /// An exception will be thrown if a DBusValue in [children] doesn't have a signature matching [childSignature].
   DBusArray(this.childSignature, [Iterable<DBusValue> children = const []])
-      : children = children.toList() {
+    : children = children.toList() {
     if (!childSignature.isSingleCompleteType) {
-      throw ArgumentError.value(childSignature, 'childSignature',
-          'Array value type must be a single complete type');
+      throw ArgumentError.value(
+        childSignature,
+        'childSignature',
+        'Array value type must be a single complete type',
+      );
     }
 
     for (var child in children) {
       if (child.signature.value != childSignature.value) {
-        throw ArgumentError.value(children, 'children',
-            "Provided children don't match array signature ${childSignature.value}");
+        throw ArgumentError.value(
+          children,
+          'children',
+          "Provided children don't match array signature ${childSignature.value}",
+        );
       }
     }
   }
@@ -909,68 +943,89 @@ class DBusArray extends DBusValue {
   /// No checking is performed on the validity of [children].
   /// This function is useful when you need a constant value (e.g. for a
   /// parameter default value). In all other cases use the standard constructor.
-  DBusArray.unchecked(this.childSignature,
-      [Iterable<DBusValue> children = const []])
-      : children = children.toList();
+  DBusArray.unchecked(
+    this.childSignature, [
+    Iterable<DBusValue> children = const [],
+  ]) : children = children.toList();
 
   /// Creates a new array of unsigned 8 bit values.
   factory DBusArray.byte(Iterable<int> values) {
     return DBusArray(
-        DBusSignature('y'), values.map((value) => DBusByte(value)));
+      DBusSignature('y'),
+      values.map((value) => DBusByte(value)),
+    );
   }
 
   /// Creates a new array of boolean values.
   factory DBusArray.boolean(Iterable<bool> values) {
     return DBusArray(
-        DBusSignature('b'), values.map((value) => DBusBoolean(value)));
+      DBusSignature('b'),
+      values.map((value) => DBusBoolean(value)),
+    );
   }
 
   /// Creates a new array of signed 16 bit values.
   factory DBusArray.int16(Iterable<int> values) {
     return DBusArray(
-        DBusSignature('n'), values.map((value) => DBusInt16(value)));
+      DBusSignature('n'),
+      values.map((value) => DBusInt16(value)),
+    );
   }
 
   /// Creates a new array of unsigned 16 bit values.
   factory DBusArray.uint16(Iterable<int> values) {
     return DBusArray(
-        DBusSignature('q'), values.map((value) => DBusUint16(value)));
+      DBusSignature('q'),
+      values.map((value) => DBusUint16(value)),
+    );
   }
 
   /// Creates a new array of signed 32 bit values.
   factory DBusArray.int32(Iterable<int> values) {
     return DBusArray(
-        DBusSignature('i'), values.map((value) => DBusInt32(value)));
+      DBusSignature('i'),
+      values.map((value) => DBusInt32(value)),
+    );
   }
 
   /// Creates a new array of unsigned 32 bit values.
   factory DBusArray.uint32(Iterable<int> values) {
     return DBusArray(
-        DBusSignature('u'), values.map((value) => DBusUint32(value)));
+      DBusSignature('u'),
+      values.map((value) => DBusUint32(value)),
+    );
   }
 
   /// Creates a new array of signed 64 bit values.
   factory DBusArray.int64(Iterable<int> values) {
     return DBusArray(
-        DBusSignature('x'), values.map((value) => DBusInt64(value)));
+      DBusSignature('x'),
+      values.map((value) => DBusInt64(value)),
+    );
   }
 
   /// Creates a new array of unsigned 64 bit values.
   factory DBusArray.uint64(Iterable<int> values) {
     return DBusArray(
-        DBusSignature('t'), values.map((value) => DBusUint64(value)));
+      DBusSignature('t'),
+      values.map((value) => DBusUint64(value)),
+    );
   }
 
   /// Creates a new array of 64 bit floating point values.
   factory DBusArray.double(Iterable<double> values) {
     return DBusArray(
-        DBusSignature('d'), values.map((value) => DBusDouble(value)));
+      DBusSignature('d'),
+      values.map((value) => DBusDouble(value)),
+    );
   }
 
   /// Creates a new array of Unicode text strings.
   factory DBusArray.string(Iterable<String> values) {
     return DBusArray(
-        DBusSignature('s'), values.map((value) => DBusString(value)));
+      DBusSignature('s'),
+      values.map((value) => DBusString(value)),
+    );
   }
 
   /// Creates a new array of D-Bus object paths.
@@ -986,13 +1041,17 @@ class DBusArray extends DBusValue {
   /// Creates a new array of D-Bus variants.
   factory DBusArray.variant(Iterable<DBusValue> values) {
     return DBusArray(
-        DBusSignature('v'), values.map((value) => DBusVariant(value)));
+      DBusSignature('v'),
+      values.map((value) => DBusVariant(value)),
+    );
   }
 
   /// Creates a new array of Unix file descriptors.
   factory DBusArray.unixFd(Iterable<ResourceHandle> values) {
     return DBusArray(
-        DBusSignature('h'), values.map((value) => DBusUnixFd(value)));
+      DBusSignature('h'),
+      values.map((value) => DBusUnixFd(value)),
+    );
   }
 
   @override
@@ -1091,16 +1150,19 @@ class DBusArray extends DBusValue {
         var values = children.map((child) => child.asDouble()).join(', ');
         return 'DBusArray.double([$values])';
       case 's':
-        var values =
-            children.map((child) => "'${child.asString()}'").join(', ');
+        var values = children
+            .map((child) => "'${child.asString()}'")
+            .join(', ');
         return 'DBusArray.string([$values])';
       case 'o':
-        var values =
-            children.map((child) => child.asObjectPath().toString()).join(', ');
+        var values = children
+            .map((child) => child.asObjectPath().toString())
+            .join(', ');
         return 'DBusArray.objectPath([$values])';
       case 'g':
-        var values =
-            children.map((child) => child.asSignature().toString()).join(', ');
+        var values = children
+            .map((child) => child.asSignature().toString())
+            .join(', ');
         return 'DBusArray.signature([$values])';
       case 'v':
         var values = children.map((child) => child.asVariant()).join(', ');
@@ -1137,22 +1199,34 @@ class DBusDict extends DBusValue {
   /// An exception will be thrown if the DBusValues in [children] don't have signatures matching [keySignature] and [valueSignature].
   DBusDict(this.keySignature, this.valueSignature, [this.children = const {}]) {
     if (!keySignature.isSingleCompleteType) {
-      throw ArgumentError.value(keySignature, 'keySignature',
-          'Dict key type must be a single complete type');
+      throw ArgumentError.value(
+        keySignature,
+        'keySignature',
+        'Dict key type must be a single complete type',
+      );
     }
     if (!valueSignature.isSingleCompleteType) {
-      throw ArgumentError.value(valueSignature, 'valueSignature',
-          'Dict value type must be a single complete type');
+      throw ArgumentError.value(
+        valueSignature,
+        'valueSignature',
+        'Dict value type must be a single complete type',
+      );
     }
 
     children.forEach((key, value) {
       if (key.signature.value != keySignature.value) {
-        throw ArgumentError.value(key, 'children',
-            "Provided key doesn't match signature ${keySignature.value}");
+        throw ArgumentError.value(
+          key,
+          'children',
+          "Provided key doesn't match signature ${keySignature.value}",
+        );
       }
       if (value.signature.value != valueSignature.value) {
-        throw ArgumentError.value(value, 'children',
-            "Provided value doesn't match signature ${valueSignature.value}");
+        throw ArgumentError.value(
+          value,
+          'children',
+          "Provided value doesn't match signature ${valueSignature.value}",
+        );
       }
     });
   }
@@ -1162,16 +1236,21 @@ class DBusDict extends DBusValue {
   /// No checking is performed on the validity of [children].
   /// This function is useful when you need a constant value (e.g. for a
   /// parameter default value). In all other cases use the standard constructor.
-  const DBusDict.unchecked(this.keySignature, this.valueSignature,
-      [this.children = const {}]);
+  const DBusDict.unchecked(
+    this.keySignature,
+    this.valueSignature, [
+    this.children = const {},
+  ]);
 
   /// Creates a new dictionary of string keys mapping to variant values.
   factory DBusDict.stringVariant(Map<String, DBusValue> children) {
     return DBusDict(
-        DBusSignature('s'),
-        DBusSignature('v'),
-        children.map(
-            (key, value) => MapEntry(DBusString(key), DBusVariant(value))));
+      DBusSignature('s'),
+      DBusSignature('v'),
+      children.map(
+        (key, value) => MapEntry(DBusString(key), DBusVariant(value)),
+      ),
+    );
   }
 
   @override
@@ -1181,8 +1260,9 @@ class DBusDict extends DBusValue {
 
   @override
   dynamic toNative() {
-    return children
-        .map((key, value) => MapEntry(key.toNative(), value.toNative()));
+    return children.map(
+      (key, value) => MapEntry(key.toNative(), value.toNative()),
+    );
   }
 
   /// Maps the contents of this array into native types. Only works if [keySignature] is 's' and [valueSignature] is 'v'.
@@ -1198,14 +1278,17 @@ class DBusDict extends DBusValue {
 
   @override
   int get hashCode => Object.hashAll(
-      children.entries.map((entry) => Object.hash(entry.key, entry.value)));
+    children.entries.map((entry) => Object.hash(entry.key, entry.value)),
+  );
 
   @override
   String toString() {
     if (keySignature.value == 's' && valueSignature.value == 'v') {
       var values = children.entries
-          .map((entry) =>
-              "'${entry.key.asString()}': ${entry.value.asVariant().toString()}")
+          .map(
+            (entry) =>
+                "'${entry.key.asString()}': ${entry.value.asVariant().toString()}",
+          )
           .join(', ');
       return 'DBusDict.stringVariant({$values})';
     } else {

--- a/lib/src/dbus_value.dart
+++ b/lib/src/dbus_value.dart
@@ -457,7 +457,7 @@ class DBusObjectPath extends DBusString {
   /// No checking is performed on the validity of [value].
   /// This function is useful when you need a constant value (e.g. for a
   /// parameter default value). In all other cases use the standard constructor.
-  const DBusObjectPath.unchecked(String value) : super(value);
+  const DBusObjectPath.unchecked(super.value);
 
   /// The root object path ("/").
   static const DBusObjectPath root = DBusObjectPath.unchecked('/');

--- a/lib/src/dbus_write_buffer.dart
+++ b/lib/src/dbus_write_buffer.dart
@@ -23,19 +23,24 @@ class DBusWriteBuffer extends DBusBuffer {
     }
 
     writeValue(DBusByte(108)); // Little endian (ASCII 'l')
-    writeValue(DBusByte({
-          DBusMessageType.methodCall: 1,
-          DBusMessageType.methodReturn: 2,
-          DBusMessageType.error: 3,
-          DBusMessageType.signal: 4
-        }[message.type] ??
-        0));
+    writeValue(
+      DBusByte(
+        {
+              DBusMessageType.methodCall: 1,
+              DBusMessageType.methodReturn: 2,
+              DBusMessageType.error: 3,
+              DBusMessageType.signal: 4,
+            }[message.type] ??
+            0,
+      ),
+    );
     var flagsValue = 0;
     for (var flag in message.flags) {
-      flagsValue |= {
+      flagsValue |=
+          {
             DBusMessageFlag.noReplyExpected: 0x01,
             DBusMessageFlag.noAutoStart: 0x02,
-            DBusMessageFlag.allowInteractiveAuthorization: 0x04
+            DBusMessageFlag.allowInteractiveAuthorization: 0x04,
           }[flag] ??
           0;
     }
@@ -73,8 +78,9 @@ class DBusWriteBuffer extends DBusBuffer {
       headers.add(_makeHeader(8, DBusSignature(signature)));
     }
     if (valueBuffer.resourceHandles.isNotEmpty) {
-      headers
-          .add(_makeHeader(9, DBusUint32(valueBuffer.resourceHandles.length)));
+      headers.add(
+        _makeHeader(9, DBusUint32(valueBuffer.resourceHandles.length)),
+      );
     }
     writeValue(DBusArray(DBusSignature('(yv)'), headers));
     align(8);
@@ -184,7 +190,8 @@ class DBusWriteBuffer extends DBusBuffer {
     } else if (value is DBusSignature) {
       if (value.value.contains('m')) {
         throw UnsupportedError(
-            "D-Bus doesn't support reserved maybe type in signatures");
+          "D-Bus doesn't support reserved maybe type in signatures",
+        );
       }
       var data = utf8.encode(value.value);
       writeByte(data.length);
@@ -227,7 +234,8 @@ class DBusWriteBuffer extends DBusBuffer {
     } else if (value is DBusDict) {
       if (!value.keySignature.isBasic) {
         throw UnsupportedError(
-            "D-Bus doesn't support dicts with non basic key types");
+          "D-Bus doesn't support dicts with non basic key types",
+        );
       }
 
       // Length will be overwritten later.

--- a/lib/src/getsid_windows.dart
+++ b/lib/src/getsid_windows.dart
@@ -22,36 +22,54 @@ String getsid() {
   final kernel32 = DynamicLibrary.open('kernel32.dll');
   final getCurrentProcess = kernel32
       .lookupFunction<IntPtr Function(), int Function()>('GetCurrentProcess');
-  final closeHandle = kernel32.lookupFunction<Int32 Function(IntPtr hObject),
-      int Function(int hObject)>('CloseHandle');
+  final closeHandle = kernel32
+      .lookupFunction<
+        Int32 Function(IntPtr hObject),
+        int Function(int hObject)
+      >('CloseHandle');
   final getLastError = kernel32
       .lookupFunction<Uint32 Function(), int Function()>('GetLastError');
-  final localFree = kernel32.lookupFunction<IntPtr Function(IntPtr hMem),
-      int Function(int hMem)>('LocalFree');
+  final localFree = kernel32
+      .lookupFunction<IntPtr Function(IntPtr hMem), int Function(int hMem)>(
+        'LocalFree',
+      );
 
   final advapi32 = DynamicLibrary.open('advapi32.dll');
-  final openProcessToken = advapi32.lookupFunction<
-      Int32 Function(IntPtr processHandle, Uint32 desiredAccess,
-          Pointer<IntPtr> tokenHandle),
-      int Function(int processHandle, int desiredAccess,
-          Pointer<IntPtr> tokenHandle)>('OpenProcessToken');
-  final getTokenInformation = advapi32.lookupFunction<
-      Int32 Function(
+  final openProcessToken = advapi32
+      .lookupFunction<
+        Int32 Function(
+          IntPtr processHandle,
+          Uint32 desiredAccess,
+          Pointer<IntPtr> tokenHandle,
+        ),
+        int Function(
+          int processHandle,
+          int desiredAccess,
+          Pointer<IntPtr> tokenHandle,
+        )
+      >('OpenProcessToken');
+  final getTokenInformation = advapi32
+      .lookupFunction<
+        Int32 Function(
           IntPtr tokenHandle,
           Uint32 tokenInformationClass,
           Pointer tokenInformation,
           Uint32 tokenInformationLength,
-          Pointer<Uint32> returnLength),
-      int Function(
+          Pointer<Uint32> returnLength,
+        ),
+        int Function(
           int tokenHandle,
           int tokenInformationClass,
           Pointer tokenInformation,
           int tokenInformationLength,
-          Pointer<Uint32> returnLength)>('GetTokenInformation');
-  final convertSidToStringSidA = advapi32.lookupFunction<
-      Int32 Function(Pointer<Void> sid, Pointer<Pointer<Utf8>> stringSid),
-      int Function(Pointer<Void> sid,
-          Pointer<Pointer<Utf8>> stringSid)>('ConvertSidToStringSidA');
+          Pointer<Uint32> returnLength,
+        )
+      >('GetTokenInformation');
+  final convertSidToStringSidA = advapi32
+      .lookupFunction<
+        Int32 Function(Pointer<Void> sid, Pointer<Pointer<Utf8>> stringSid),
+        int Function(Pointer<Void> sid, Pointer<Pointer<Utf8>> stringSid)
+      >('ConvertSidToStringSidA');
 
   const tokenQuery = 0x0008;
   var h = calloc<IntPtr>();

--- a/lib/src/getsid_windows.dart
+++ b/lib/src/getsid_windows.dart
@@ -3,13 +3,13 @@ import 'dart:io';
 
 import 'package:ffi/ffi.dart';
 
-class _SidAndAttributes extends Struct {
+final class _SidAndAttributes extends Struct {
   external Pointer<Void> sid;
   @Uint32()
   external int attributes;
 }
 
-class _TokenUser extends Struct {
+final class _TokenUser extends Struct {
   external _SidAndAttributes user;
 }
 

--- a/lib/src/getuid_linux.dart
+++ b/lib/src/getuid_linux.dart
@@ -8,7 +8,8 @@ typedef _GetuidDart = int Function();
 int getuid() {
   if (!Platform.isLinux) {
     throw UnsupportedError(
-        'Unable to determine UID on: ${Platform.operatingSystem}');
+      'Unable to determine UID on: ${Platform.operatingSystem}',
+    );
   }
 
   final dylib = DynamicLibrary.open('libc.so.6');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ description:
 homepage: https://github.com/canonical/dbus.dart
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=3.11.0 <4.0.0"
 
 platforms:
   linux:
@@ -18,10 +18,10 @@ dependencies:
   args: ^2.0.0
   ffi: ^2.0.0
   meta: ^1.3.0
-  xml: ^6.6.1
+  xml: ^7.0.1
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^6.1.0
   test: ^1.16.8
   test_cov: ^1.0.1
 

--- a/test/dbus_test.dart
+++ b/test/dbus_test.dart
@@ -15,8 +15,10 @@ import 'package:test/test.dart';
 // Test server that exposes an activatable service.
 class ServerWithActivatableService extends DBusServer {
   @override
-  List<String> get activatableNames =>
-      ['com.example.NotRunning', 'com.example.AlreadyRunning'];
+  List<String> get activatableNames => [
+    'com.example.NotRunning',
+    'com.example.AlreadyRunning',
+  ];
 
   @override
   Future<DBusServerStartServiceResult> startServiceByName(String name) async {
@@ -60,20 +62,20 @@ class TestObject extends DBusObject {
   // Interfaces reported by an object manager.
   final Map<String, Map<String, DBusValue>> interfacesAndProperties_;
 
-  TestObject(
-      {DBusObjectPath path = const DBusObjectPath.unchecked('/'),
-      this.expectedMethodName,
-      this.expectedMethodValues,
-      this.expectedMethodNoReplyExpected = false,
-      this.expectedMethodNoAutoStart = false,
-      this.expectedMethodAllowInteractiveAuthorization = false,
-      this.methodResponses = const {},
-      this.introspectData = const [],
-      this.propertyValues = const {},
-      this.propertyGetErrors = const {},
-      this.propertySetErrors = const {},
-      this.interfacesAndProperties_ = const {}})
-      : super(path);
+  TestObject({
+    DBusObjectPath path = const DBusObjectPath.unchecked('/'),
+    this.expectedMethodName,
+    this.expectedMethodValues,
+    this.expectedMethodNoReplyExpected = false,
+    this.expectedMethodNoAutoStart = false,
+    this.expectedMethodAllowInteractiveAuthorization = false,
+    this.methodResponses = const {},
+    this.introspectData = const [],
+    this.propertyValues = const {},
+    this.propertyGetErrors = const {},
+    this.propertySetErrors = const {},
+    this.interfacesAndProperties_ = const {},
+  }) : super(path);
 
   void updateInterface(String name, Map<String, DBusValue> properties) {
     interfacesAndProperties_[name] = properties;
@@ -97,8 +99,10 @@ class TestObject extends DBusObject {
     }
     expect(methodCall.noReplyExpected, equals(expectedMethodNoReplyExpected));
     expect(methodCall.noAutoStart, equals(expectedMethodNoAutoStart));
-    expect(methodCall.allowInteractiveAuthorization,
-        equals(expectedMethodAllowInteractiveAuthorization));
+    expect(
+      methodCall.allowInteractiveAuthorization,
+      equals(expectedMethodAllowInteractiveAuthorization),
+    );
 
     var response = methodResponses[name];
     if (response == null) {
@@ -138,7 +142,10 @@ class TestObject extends DBusObject {
 
   @override
   Future<DBusMethodResponse> setProperty(
-      String interface, String name, DBusValue value) async {
+    String interface,
+    String name,
+    DBusValue value,
+  ) async {
     var propertyName = '$interface.$name';
     var response = propertySetErrors[propertyName];
     if (response != null) {
@@ -181,7 +188,8 @@ class TestManagerObject extends DBusObject {
   @override
   Future<DBusMethodResponse> handleMethodCall(DBusMethodCall methodCall) async {
     await client?.registerObject(
-        TestObject(path: DBusObjectPath('/com/example/Object1')));
+      TestObject(path: DBusObjectPath('/com/example/Object1')),
+    );
     return DBusMethodSuccessResponse();
   }
 }
@@ -383,7 +391,7 @@ void main() {
     var map = {
       DBusString('one'): 1,
       DBusString('two'): 2,
-      DBusString('three'): 3
+      DBusString('three'): 3,
     };
     expect(map[DBusString('two')], equals(2));
   });
@@ -392,10 +400,14 @@ void main() {
     expect(DBusObjectPath('/').value, equals('/'));
     expect(DBusObjectPath('/com').value, equals('/com'));
     expect(
-        DBusObjectPath('/com/example/Test').value, equals('/com/example/Test'));
+      DBusObjectPath('/com/example/Test').value,
+      equals('/com/example/Test'),
+    );
     // Unchecked constructor equivalent to standard constructor.
-    expect(DBusObjectPath.unchecked('/com/example/Test'),
-        equals(DBusObjectPath('/com/example/Test')));
+    expect(
+      DBusObjectPath.unchecked('/com/example/Test'),
+      equals(DBusObjectPath('/com/example/Test')),
+    );
     // Empty.
     expect(() => DBusObjectPath(''), throwsArgumentError);
     // Empty element.
@@ -408,57 +420,80 @@ void main() {
     // Invalid characters
     expect(() => DBusObjectPath(r'/com/example/Te$t'), throwsArgumentError);
     expect(() => DBusObjectPath(r'/com/example/T😄st'), throwsArgumentError);
-    expect(DBusObjectPath('/com/example/Test').signature,
-        equals(DBusSignature('o')));
-    expect(DBusObjectPath('/com/example/Test').asObjectPath(),
-        equals(DBusObjectPath('/com/example/Test')));
-    expect(DBusObjectPath('/com/example/Test').toNative(),
-        equals(DBusObjectPath('/com/example/Test')));
     expect(
-        DBusObjectPath('/com/example/Test') ==
-            DBusObjectPath('/com/example/Test'),
-        isTrue);
+      DBusObjectPath('/com/example/Test').signature,
+      equals(DBusSignature('o')),
+    );
     expect(
-        DBusObjectPath('/com/example/Test') ==
-            DBusObjectPath('/com/example/Test2'),
-        isFalse);
+      DBusObjectPath('/com/example/Test').asObjectPath(),
+      equals(DBusObjectPath('/com/example/Test')),
+    );
     expect(
-        DBusObjectPath('/com/example/Test')
-            .isInNamespace(DBusObjectPath('/com/example/Test')),
-        isTrue);
+      DBusObjectPath('/com/example/Test').toNative(),
+      equals(DBusObjectPath('/com/example/Test')),
+    );
     expect(
-        DBusObjectPath('/com/example/Test')
-            .isInNamespace(DBusObjectPath('/com/example')),
-        isTrue);
+      DBusObjectPath('/com/example/Test') ==
+          DBusObjectPath('/com/example/Test'),
+      isTrue,
+    );
     expect(
-        DBusObjectPath('/com/example/Test')
-            .isInNamespace(DBusObjectPath('/com')),
-        isTrue);
+      DBusObjectPath('/com/example/Test') ==
+          DBusObjectPath('/com/example/Test2'),
+      isFalse,
+    );
     expect(
-        DBusObjectPath('/com/example/Test').isInNamespace(DBusObjectPath('/')),
-        isTrue);
+      DBusObjectPath(
+        '/com/example/Test',
+      ).isInNamespace(DBusObjectPath('/com/example/Test')),
+      isTrue,
+    );
     expect(
-        DBusObjectPath('/com/example/Test')
-            .isInNamespace(DBusObjectPath('/com/example/Test2')),
-        isFalse);
+      DBusObjectPath(
+        '/com/example/Test',
+      ).isInNamespace(DBusObjectPath('/com/example')),
+      isTrue,
+    );
     expect(
-        DBusObjectPath('/com/example/Test')
-            .isInNamespace(DBusObjectPath('/com/example2')),
-        isFalse);
+      DBusObjectPath('/com/example/Test').isInNamespace(DBusObjectPath('/com')),
+      isTrue,
+    );
     expect(
-        DBusObjectPath('/com/example/Test')
-            .isInNamespace(DBusObjectPath('/com2/example')),
-        isFalse);
-    expect(DBusObjectPath('/com/example/Test').toString(),
-        equals("DBusObjectPath('/com/example/Test')"));
-    expect(DBusObjectPath('/com/example/Test').signature,
-        equals(DBusSignature.objectPath));
+      DBusObjectPath('/com/example/Test').isInNamespace(DBusObjectPath('/')),
+      isTrue,
+    );
+    expect(
+      DBusObjectPath(
+        '/com/example/Test',
+      ).isInNamespace(DBusObjectPath('/com/example/Test2')),
+      isFalse,
+    );
+    expect(
+      DBusObjectPath(
+        '/com/example/Test',
+      ).isInNamespace(DBusObjectPath('/com/example2')),
+      isFalse,
+    );
+    expect(
+      DBusObjectPath(
+        '/com/example/Test',
+      ).isInNamespace(DBusObjectPath('/com2/example')),
+      isFalse,
+    );
+    expect(
+      DBusObjectPath('/com/example/Test').toString(),
+      equals("DBusObjectPath('/com/example/Test')"),
+    );
+    expect(
+      DBusObjectPath('/com/example/Test').signature,
+      equals(DBusSignature.objectPath),
+    );
 
     // Check hash codes.
     var map = {
       DBusObjectPath('/one'): 1,
       DBusObjectPath('/two'): 2,
-      DBusObjectPath('/three'): 3
+      DBusObjectPath('/three'): 3,
     };
     expect(map[DBusObjectPath('/two')], equals(2));
   });
@@ -544,13 +579,14 @@ void main() {
     expect(() => DBusSignature('a{s}'), throwsArgumentError);
     expect(() => DBusSignature('a{siv}'), throwsArgumentError);
     expect(
-        DBusSignature('ybnq').split(),
-        equals([
-          DBusSignature('y'),
-          DBusSignature('b'),
-          DBusSignature('n'),
-          DBusSignature('q')
-        ]));
+      DBusSignature('ybnq').split(),
+      equals([
+        DBusSignature('y'),
+        DBusSignature('b'),
+        DBusSignature('n'),
+        DBusSignature('q'),
+      ]),
+    );
     expect(DBusSignature('(ybnq)').split(), equals([DBusSignature('(ybnq)')]));
     expect(DBusSignature('').split(), equals([]));
     expect(DBusSignature('s').signature, equals(DBusSignature('g')));
@@ -559,13 +595,15 @@ void main() {
     expect(DBusSignature('a{sv}') == DBusSignature('a{sv}'), isTrue);
     expect(DBusSignature('a{sv}') == DBusSignature('s'), isFalse);
     expect(
-        DBusSignature('(ybnq)').toString(), equals("DBusSignature('(ybnq)')"));
+      DBusSignature('(ybnq)').toString(),
+      equals("DBusSignature('(ybnq)')"),
+    );
 
     // Check hash codes.
     var map = {
       DBusSignature('n'): 16,
       DBusSignature('i'): 32,
-      DBusSignature('t'): 64
+      DBusSignature('t'): 64,
     };
     expect(map[DBusSignature('i')], equals(32));
   });
@@ -574,58 +612,87 @@ void main() {
     expect(DBusVariant(DBusString('one')).value, equals(DBusString('one')));
     expect(DBusVariant(DBusUint32(2)).value, equals(DBusUint32(2)));
     expect(
-        DBusVariant(DBusString('one')).signature, equals(DBusSignature('v')));
+      DBusVariant(DBusString('one')).signature,
+      equals(DBusSignature('v')),
+    );
     expect(
-        DBusVariant(DBusString('one')).asVariant(), equals(DBusString('one')));
+      DBusVariant(DBusString('one')).asVariant(),
+      equals(DBusString('one')),
+    );
     expect(DBusVariant(DBusString('one')).toNative(), equals('one'));
-    expect(DBusVariant(DBusString('one')) == DBusVariant(DBusString('one')),
-        isTrue);
     expect(
-        DBusVariant(DBusString('one')) == DBusVariant(DBusUint32(2)), isFalse);
-    expect(DBusVariant(DBusString('one')).toString(),
-        equals("DBusVariant(DBusString('one'))"));
-    expect(DBusVariant(DBusString('one')).signature,
-        equals(DBusSignature.variant));
+      DBusVariant(DBusString('one')) == DBusVariant(DBusString('one')),
+      isTrue,
+    );
+    expect(
+      DBusVariant(DBusString('one')) == DBusVariant(DBusUint32(2)),
+      isFalse,
+    );
+    expect(
+      DBusVariant(DBusString('one')).toString(),
+      equals("DBusVariant(DBusString('one'))"),
+    );
+    expect(
+      DBusVariant(DBusString('one')).signature,
+      equals(DBusSignature.variant),
+    );
 
     // Check hash codes.
     var map = {
       DBusVariant(DBusUint32(1)): 1,
       DBusVariant(DBusString('two')): 2,
-      DBusVariant(DBusDouble(3.14159)): 3
+      DBusVariant(DBusDouble(3.14159)): 3,
     };
     expect(map[DBusVariant(DBusString('two'))], equals(2));
   });
 
   test('value - maybe', () async {
-    expect(DBusMaybe(DBusSignature('s'), DBusString('one')).value,
-        equals(DBusString('one')));
+    expect(
+      DBusMaybe(DBusSignature('s'), DBusString('one')).value,
+      equals(DBusString('one')),
+    );
     expect(DBusMaybe(DBusSignature('s'), null).value, isNull);
     expect(
-        () => DBusMaybe(DBusSignature('s'), DBusInt32(1)), throwsArgumentError);
-    expect(DBusMaybe(DBusSignature('s'), null).signature,
-        equals(DBusSignature('ms')));
-    expect(DBusMaybe(DBusSignature('s'), DBusString('one')).asMaybe(),
-        equals(DBusString('one')));
-    expect(DBusMaybe(DBusSignature('s'), DBusString('one')).toNative(),
-        equals('one'));
+      () => DBusMaybe(DBusSignature('s'), DBusInt32(1)),
+      throwsArgumentError,
+    );
+    expect(
+      DBusMaybe(DBusSignature('s'), null).signature,
+      equals(DBusSignature('ms')),
+    );
+    expect(
+      DBusMaybe(DBusSignature('s'), DBusString('one')).asMaybe(),
+      equals(DBusString('one')),
+    );
+    expect(
+      DBusMaybe(DBusSignature('s'), DBusString('one')).toNative(),
+      equals('one'),
+    );
     expect(DBusMaybe(DBusSignature('s'), null).asMaybe(), isNull);
     expect(DBusMaybe(DBusSignature('s'), null).toNative(), isNull);
     expect(
-        DBusMaybe(DBusSignature('s'), DBusString('one')) ==
-            DBusMaybe(DBusSignature('s'), DBusString('one')),
-        isTrue);
+      DBusMaybe(DBusSignature('s'), DBusString('one')) ==
+          DBusMaybe(DBusSignature('s'), DBusString('one')),
+      isTrue,
+    );
     expect(
-        DBusMaybe(DBusSignature('s'), DBusString('one')) ==
-            DBusMaybe(DBusSignature('s'), null),
-        isFalse);
+      DBusMaybe(DBusSignature('s'), DBusString('one')) ==
+          DBusMaybe(DBusSignature('s'), null),
+      isFalse,
+    );
     expect(
-        DBusMaybe(DBusSignature('s'), DBusString('as')) ==
-            DBusMaybe(DBusSignature('g'), DBusSignature('as')),
-        isFalse);
-    expect(DBusMaybe(DBusSignature('s'), DBusString('one')).toString(),
-        equals("DBusMaybe(DBusSignature('s'), DBusString('one'))"));
-    expect(DBusMaybe(DBusSignature('s'), null).signature,
-        equals(DBusSignature.maybe(DBusSignature.string)));
+      DBusMaybe(DBusSignature('s'), DBusString('as')) ==
+          DBusMaybe(DBusSignature('g'), DBusSignature('as')),
+      isFalse,
+    );
+    expect(
+      DBusMaybe(DBusSignature('s'), DBusString('one')).toString(),
+      equals("DBusMaybe(DBusSignature('s'), DBusString('one'))"),
+    );
+    expect(
+      DBusMaybe(DBusSignature('s'), null).signature,
+      equals(DBusSignature.maybe(DBusSignature.string)),
+    );
   });
 
   test('value - unix fd', () async {
@@ -648,48 +715,68 @@ void main() {
   test('value - struct', () async {
     expect(DBusStruct([]).children, equals([]));
     expect(
-        DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)])
-            .children,
-        equals([DBusString('one'), DBusUint32(2), DBusDouble(3.0)]));
+      DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)]).children,
+      equals([DBusString('one'), DBusUint32(2), DBusDouble(3.0)]),
+    );
     expect(DBusStruct([]).signature, equals(DBusSignature('()')));
     expect(
-        DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)])
-            .asStruct(),
-        equals([DBusString('one'), DBusUint32(2), DBusDouble(3.0)]));
+      DBusStruct([
+        DBusString('one'),
+        DBusUint32(2),
+        DBusDouble(3.0),
+      ]).asStruct(),
+      equals([DBusString('one'), DBusUint32(2), DBusDouble(3.0)]),
+    );
     expect(
-        DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)])
-            .toNative(),
-        equals(['one', 2, 3.0]));
+      DBusStruct([
+        DBusString('one'),
+        DBusUint32(2),
+        DBusDouble(3.0),
+      ]).toNative(),
+      equals(['one', 2, 3.0]),
+    );
     expect(
-        DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)])
-            .signature,
-        equals(DBusSignature('(sud)')));
+      DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)]).signature,
+      equals(DBusSignature('(sud)')),
+    );
     expect(
-        DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)]) ==
-            DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)]),
-        isTrue);
+      DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)]) ==
+          DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)]),
+      isTrue,
+    );
     expect(
-        DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)]) ==
-            DBusStruct([DBusString('one'), DBusInt32(2), DBusDouble(3.0)]),
-        isFalse);
+      DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)]) ==
+          DBusStruct([DBusString('one'), DBusInt32(2), DBusDouble(3.0)]),
+      isFalse,
+    );
     expect(
-        DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)])
-            .toString(),
-        equals(
-            "DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)])"));
+      DBusStruct([
+        DBusString('one'),
+        DBusUint32(2),
+        DBusDouble(3.0),
+      ]).toString(),
+      equals("DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)])"),
+    );
     expect(
-        DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)])
-            .signature,
-        equals(DBusSignature.struct([
+      DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)]).signature,
+      equals(
+        DBusSignature.struct([
           DBusSignature.string,
           DBusSignature.uint32,
-          DBusSignature.double
-        ])));
+          DBusSignature.double,
+        ]),
+      ),
+    );
     expect(
-        DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)])
-            .hashCode,
-        equals(DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)])
-            .hashCode));
+      DBusStruct([DBusString('one'), DBusUint32(2), DBusDouble(3.0)]).hashCode,
+      equals(
+        DBusStruct([
+          DBusString('one'),
+          DBusUint32(2),
+          DBusDouble(3.0),
+        ]).hashCode,
+      ),
+    );
   });
 
   test('value - array', () async {
@@ -697,383 +784,574 @@ void main() {
     // Signature must be single complete type.
     expect(() => DBusArray(DBusSignature('si'), []), throwsArgumentError);
     expect(
-        DBusArray(DBusSignature('s'), [
-          DBusString('one'),
-          DBusString('two'),
-          DBusString('three')
-        ]).children,
-        equals([DBusString('one'), DBusString('two'), DBusString('three')]));
+      DBusArray(DBusSignature('s'), [
+        DBusString('one'),
+        DBusString('two'),
+        DBusString('three'),
+      ]).children,
+      equals([DBusString('one'), DBusString('two'), DBusString('three')]),
+    );
     // Unchecked constructor equivalent to standard constructor.
     expect(
-        DBusArray.unchecked(DBusSignature('s'),
-            [DBusString('one'), DBusString('two'), DBusString('three')]),
-        equals(DBusArray(DBusSignature('s'),
-            [DBusString('one'), DBusString('two'), DBusString('three')])));
-    expect(
-        () => DBusArray(DBusSignature('s'),
-            [DBusString('one'), DBusUint32(2), DBusDouble(3.0)]),
-        throwsArgumentError);
-    expect(DBusArray(DBusSignature('s'), []).childSignature,
-        equals(DBusSignature('s')));
-    expect(DBusArray(DBusSignature('s'), []).signature,
-        equals(DBusSignature('as')));
-    expect(
+      DBusArray.unchecked(DBusSignature('s'), [
+        DBusString('one'),
+        DBusString('two'),
+        DBusString('three'),
+      ]),
+      equals(
         DBusArray(DBusSignature('s'), [
           DBusString('one'),
           DBusString('two'),
-          DBusString('three')
-        ]).asArray(),
-        equals([DBusString('one'), DBusString('two'), DBusString('three')]));
+          DBusString('three'),
+        ]),
+      ),
+    );
     expect(
-        DBusArray(DBusSignature('s'), [
-          DBusString('one'),
-          DBusString('two'),
-          DBusString('three')
-        ]).toNative(),
-        equals(['one', 'two', 'three']));
+      () => DBusArray(DBusSignature('s'), [
+        DBusString('one'),
+        DBusUint32(2),
+        DBusDouble(3.0),
+      ]),
+      throwsArgumentError,
+    );
     expect(
-        DBusArray(DBusSignature('s'),
-                [DBusString('one'), DBusString('two'), DBusString('three')]) ==
-            DBusArray(DBusSignature('s'),
-                [DBusString('one'), DBusString('two'), DBusString('three')]),
-        isTrue);
+      DBusArray(DBusSignature('s'), []).childSignature,
+      equals(DBusSignature('s')),
+    );
     expect(
-        DBusArray(DBusSignature('s'),
-                [DBusString('one'), DBusString('two'), DBusString('three')]) ==
-            DBusArray(DBusSignature('s'),
-                [DBusString('three'), DBusString('two'), DBusString('one')]),
-        isFalse);
+      DBusArray(DBusSignature('s'), []).signature,
+      equals(DBusSignature('as')),
+    );
+    expect(
+      DBusArray(DBusSignature('s'), [
+        DBusString('one'),
+        DBusString('two'),
+        DBusString('three'),
+      ]).asArray(),
+      equals([DBusString('one'), DBusString('two'), DBusString('three')]),
+    );
+    expect(
+      DBusArray(DBusSignature('s'), [
+        DBusString('one'),
+        DBusString('two'),
+        DBusString('three'),
+      ]).toNative(),
+      equals(['one', 'two', 'three']),
+    );
+    expect(
+      DBusArray(DBusSignature('s'), [
+            DBusString('one'),
+            DBusString('two'),
+            DBusString('three'),
+          ]) ==
+          DBusArray(DBusSignature('s'), [
+            DBusString('one'),
+            DBusString('two'),
+            DBusString('three'),
+          ]),
+      isTrue,
+    );
+    expect(
+      DBusArray(DBusSignature('s'), [
+            DBusString('one'),
+            DBusString('two'),
+            DBusString('three'),
+          ]) ==
+          DBusArray(DBusSignature('s'), [
+            DBusString('three'),
+            DBusString('two'),
+            DBusString('one'),
+          ]),
+      isFalse,
+    );
 
     // Check factory constructors are equivalent to their full expansions.
     expect(
-        DBusArray.byte([1, 2, 3]),
-        equals(DBusArray(
-            DBusSignature('y'), [DBusByte(1), DBusByte(2), DBusByte(3)])));
+      DBusArray.byte([1, 2, 3]),
+      equals(
+        DBusArray(DBusSignature('y'), [DBusByte(1), DBusByte(2), DBusByte(3)]),
+      ),
+    );
     expect(DBusArray.byte([1, 2, 3]).asByteArray(), equals([1, 2, 3]));
     expect(
-        DBusArray.boolean([false, true]),
-        equals(DBusArray(
-            DBusSignature('b'), [DBusBoolean(false), DBusBoolean(true)])));
-    expect(DBusArray.boolean([false, true]).asBooleanArray(),
-        equals([false, true]));
+      DBusArray.boolean([false, true]),
+      equals(
+        DBusArray(DBusSignature('b'), [DBusBoolean(false), DBusBoolean(true)]),
+      ),
+    );
     expect(
-        DBusArray.int16([1, 2, -3]),
-        equals(DBusArray(
-            DBusSignature('n'), [DBusInt16(1), DBusInt16(2), DBusInt16(-3)])));
+      DBusArray.boolean([false, true]).asBooleanArray(),
+      equals([false, true]),
+    );
+    expect(
+      DBusArray.int16([1, 2, -3]),
+      equals(
+        DBusArray(DBusSignature('n'), [
+          DBusInt16(1),
+          DBusInt16(2),
+          DBusInt16(-3),
+        ]),
+      ),
+    );
     expect(DBusArray.int16([1, 2, -3]).asInt16Array(), equals([1, 2, -3]));
     expect(
-        DBusArray.uint16([1, 2, 3]),
-        equals(DBusArray(DBusSignature('q'),
-            [DBusUint16(1), DBusUint16(2), DBusUint16(3)])));
+      DBusArray.uint16([1, 2, 3]),
+      equals(
+        DBusArray(DBusSignature('q'), [
+          DBusUint16(1),
+          DBusUint16(2),
+          DBusUint16(3),
+        ]),
+      ),
+    );
     expect(DBusArray.uint16([1, 2, 3]).asUint16Array(), equals([1, 2, 3]));
     expect(
-        DBusArray.int32([1, 2, -3]),
-        equals(DBusArray(
-            DBusSignature('i'), [DBusInt32(1), DBusInt32(2), DBusInt32(-3)])));
+      DBusArray.int32([1, 2, -3]),
+      equals(
+        DBusArray(DBusSignature('i'), [
+          DBusInt32(1),
+          DBusInt32(2),
+          DBusInt32(-3),
+        ]),
+      ),
+    );
     expect(DBusArray.int32([1, 2, -3]).asInt32Array(), equals([1, 2, -3]));
     expect(
-        DBusArray.uint32([1, 2, 3]),
-        equals(DBusArray(DBusSignature('u'),
-            [DBusUint32(1), DBusUint32(2), DBusUint32(3)])));
+      DBusArray.uint32([1, 2, 3]),
+      equals(
+        DBusArray(DBusSignature('u'), [
+          DBusUint32(1),
+          DBusUint32(2),
+          DBusUint32(3),
+        ]),
+      ),
+    );
     expect(DBusArray.uint32([1, 2, 3]).asUint32Array(), equals([1, 2, 3]));
     expect(
-        DBusArray.int64([1, 2, -3]),
-        equals(DBusArray(
-            DBusSignature('x'), [DBusInt64(1), DBusInt64(2), DBusInt64(-3)])));
+      DBusArray.int64([1, 2, -3]),
+      equals(
+        DBusArray(DBusSignature('x'), [
+          DBusInt64(1),
+          DBusInt64(2),
+          DBusInt64(-3),
+        ]),
+      ),
+    );
     expect(DBusArray.int64([1, 2, -3]).asInt64Array(), equals([1, 2, -3]));
     expect(
-        DBusArray.uint64([1, 2, 3]),
-        equals(DBusArray(DBusSignature('t'),
-            [DBusUint64(1), DBusUint64(2), DBusUint64(3)])));
+      DBusArray.uint64([1, 2, 3]),
+      equals(
+        DBusArray(DBusSignature('t'), [
+          DBusUint64(1),
+          DBusUint64(2),
+          DBusUint64(3),
+        ]),
+      ),
+    );
     expect(DBusArray.uint64([1, 2, 3]).asUint64Array(), equals([1, 2, 3]));
     expect(
-        DBusArray.double([1.1, 2.1, 3.1]),
-        equals(DBusArray(DBusSignature('d'),
-            [DBusDouble(1.1), DBusDouble(2.1), DBusDouble(3.1)])));
-    expect(DBusArray.double([1.1, 2.1, 3.1]).asDoubleArray(),
-        equals([1.1, 2.1, 3.1]));
-    expect(
-        DBusArray.string(['one', 'two', 'three']),
-        equals(DBusArray(DBusSignature('s'),
-            [DBusString('one'), DBusString('two'), DBusString('three')])));
-    expect(DBusArray.string(['one', 'two', 'three']).asStringArray(),
-        equals(['one', 'two', 'three']));
-    expect(
-        DBusArray.objectPath([
-          DBusObjectPath('/one'),
-          DBusObjectPath('/two'),
-          DBusObjectPath('/three')
+      DBusArray.double([1.1, 2.1, 3.1]),
+      equals(
+        DBusArray(DBusSignature('d'), [
+          DBusDouble(1.1),
+          DBusDouble(2.1),
+          DBusDouble(3.1),
         ]),
-        equals(DBusArray(DBusSignature('o'), [
-          DBusObjectPath('/one'),
-          DBusObjectPath('/two'),
-          DBusObjectPath('/three')
-        ])));
+      ),
+    );
     expect(
-        DBusArray.objectPath([
-          DBusObjectPath('/one'),
-          DBusObjectPath('/two'),
-          DBusObjectPath('/three')
-        ]).asObjectPathArray(),
-        equals([
-          DBusObjectPath('/one'),
-          DBusObjectPath('/two'),
-          DBusObjectPath('/three')
-        ]));
+      DBusArray.double([1.1, 2.1, 3.1]).asDoubleArray(),
+      equals([1.1, 2.1, 3.1]),
+    );
     expect(
-        DBusArray.variant(
-            [DBusInt32(1), DBusString('two'), DBusDouble(3.14159)]),
-        equals(DBusArray(DBusSignature('v'), [
+      DBusArray.string(['one', 'two', 'three']),
+      equals(
+        DBusArray(DBusSignature('s'), [
+          DBusString('one'),
+          DBusString('two'),
+          DBusString('three'),
+        ]),
+      ),
+    );
+    expect(
+      DBusArray.string(['one', 'two', 'three']).asStringArray(),
+      equals(['one', 'two', 'three']),
+    );
+    expect(
+      DBusArray.objectPath([
+        DBusObjectPath('/one'),
+        DBusObjectPath('/two'),
+        DBusObjectPath('/three'),
+      ]),
+      equals(
+        DBusArray(DBusSignature('o'), [
+          DBusObjectPath('/one'),
+          DBusObjectPath('/two'),
+          DBusObjectPath('/three'),
+        ]),
+      ),
+    );
+    expect(
+      DBusArray.objectPath([
+        DBusObjectPath('/one'),
+        DBusObjectPath('/two'),
+        DBusObjectPath('/three'),
+      ]).asObjectPathArray(),
+      equals([
+        DBusObjectPath('/one'),
+        DBusObjectPath('/two'),
+        DBusObjectPath('/three'),
+      ]),
+    );
+    expect(
+      DBusArray.variant([DBusInt32(1), DBusString('two'), DBusDouble(3.14159)]),
+      equals(
+        DBusArray(DBusSignature('v'), [
           DBusVariant(DBusInt32(1)),
           DBusVariant(DBusString('two')),
-          DBusVariant(DBusDouble(3.14159))
-        ])));
+          DBusVariant(DBusDouble(3.14159)),
+        ]),
+      ),
+    );
     expect(
-        DBusArray.variant(
-                [DBusInt32(1), DBusString('two'), DBusDouble(3.14159)])
-            .asVariantArray(),
-        equals([DBusInt32(1), DBusString('two'), DBusDouble(3.14159)]));
+      DBusArray.variant([
+        DBusInt32(1),
+        DBusString('two'),
+        DBusDouble(3.14159),
+      ]).asVariantArray(),
+      equals([DBusInt32(1), DBusString('two'), DBusDouble(3.14159)]),
+    );
     var stdinHandle = ResourceHandle.fromStdin(stdin);
     var stdoutHandle = ResourceHandle.fromStdout(stdout);
     expect(
-        DBusArray.unixFd([stdinHandle, stdoutHandle]),
-        equals(DBusArray(DBusSignature('h'),
-            [DBusUnixFd(stdinHandle), DBusUnixFd(stdoutHandle)])));
-    expect(DBusArray.unixFd([stdinHandle, stdoutHandle]).asUnixFdArray(),
-        equals([stdinHandle, stdoutHandle]));
+      DBusArray.unixFd([stdinHandle, stdoutHandle]),
+      equals(
+        DBusArray(DBusSignature('h'), [
+          DBusUnixFd(stdinHandle),
+          DBusUnixFd(stdoutHandle),
+        ]),
+      ),
+    );
+    expect(
+      DBusArray.unixFd([stdinHandle, stdoutHandle]).asUnixFdArray(),
+      equals([stdinHandle, stdoutHandle]),
+    );
 
     expect(
-        DBusArray(DBusSignature('ay'), [
-          DBusArray.byte([1, 2, 3])
-        ]).toString(),
-        equals("DBusArray(DBusSignature('ay'), [DBusArray.byte([1, 2, 3])])"));
+      DBusArray(DBusSignature('ay'), [
+        DBusArray.byte([1, 2, 3]),
+      ]).toString(),
+      equals("DBusArray(DBusSignature('ay'), [DBusArray.byte([1, 2, 3])])"),
+    );
     expect(
-        DBusArray(DBusSignature('ab'), [
-          DBusArray.boolean([false, true])
-        ]).toString(),
-        equals(
-            "DBusArray(DBusSignature('ab'), [DBusArray.boolean([false, true])])"));
-    expect(DBusArray.byte([1, 2, 3]).toString(),
-        equals('DBusArray.byte([1, 2, 3])'));
-    expect(DBusArray.int16([1, 2, -3]).toString(),
-        equals('DBusArray.int16([1, 2, -3])'));
-    expect(DBusArray.uint16([1, 2, 3]).toString(),
-        equals('DBusArray.uint16([1, 2, 3])'));
-    expect(DBusArray.int32([1, 2, -3]).toString(),
-        equals('DBusArray.int32([1, 2, -3])'));
-    expect(DBusArray.uint32([1, 2, 3]).toString(),
-        equals('DBusArray.uint32([1, 2, 3])'));
-    expect(DBusArray.int64([1, 2, -3]).toString(),
-        equals('DBusArray.int64([1, 2, -3])'));
-    expect(DBusArray.uint64([1, 2, 3]).toString(),
-        equals('DBusArray.uint64([1, 2, 3])'));
-    expect(DBusArray.double([1.1, 2.1, 3.1]).toString(),
-        equals('DBusArray.double([1.1, 2.1, 3.1])'));
-    expect(DBusArray.string(['one', 'two', 'three']).toString(),
-        equals("DBusArray.string(['one', 'two', 'three'])"));
+      DBusArray(DBusSignature('ab'), [
+        DBusArray.boolean([false, true]),
+      ]).toString(),
+      equals(
+        "DBusArray(DBusSignature('ab'), [DBusArray.boolean([false, true])])",
+      ),
+    );
     expect(
-        DBusArray.objectPath([
-          DBusObjectPath('/one'),
-          DBusObjectPath('/two'),
-          DBusObjectPath('/three')
-        ]).toString(),
-        equals(
-            "DBusArray.objectPath([DBusObjectPath('/one'), DBusObjectPath('/two'), DBusObjectPath('/three')])"));
+      DBusArray.byte([1, 2, 3]).toString(),
+      equals('DBusArray.byte([1, 2, 3])'),
+    );
     expect(
-        DBusArray.signature([DBusSignature('u'), DBusSignature('as')])
-            .toString(),
-        equals(
-            "DBusArray.signature([DBusSignature('u'), DBusSignature('as')])"));
+      DBusArray.int16([1, 2, -3]).toString(),
+      equals('DBusArray.int16([1, 2, -3])'),
+    );
     expect(
-        DBusArray.variant(
-            [DBusInt32(1), DBusString('two'), DBusDouble(3.14159)]).toString(),
-        equals(
-            "DBusArray.variant([DBusInt32(1), DBusString('two'), DBusDouble(3.14159)])"));
+      DBusArray.uint16([1, 2, 3]).toString(),
+      equals('DBusArray.uint16([1, 2, 3])'),
+    );
     expect(
-        DBusArray.variant(
-            [DBusInt32(1), DBusString('two'), DBusDouble(3.14159)]).signature,
-        equals(DBusSignature.array(DBusSignature.variant)));
+      DBusArray.int32([1, 2, -3]).toString(),
+      equals('DBusArray.int32([1, 2, -3])'),
+    );
     expect(
-        DBusArray.unixFd([stdinHandle, stdoutHandle]).toString(),
-        equals(
-            "DBusArray.unixFd([Instance of '_ResourceHandleImpl', Instance of '_ResourceHandleImpl'])"));
-    expect(DBusArray.unixFd([stdinHandle, stdoutHandle]).signature,
-        equals(DBusSignature.array(DBusSignature.unixFd)));
-    expect(DBusArray.string(['one', 'two', 'three']).hashCode,
-        equals(DBusArray.string(['one', 'two', 'three']).hashCode));
+      DBusArray.uint32([1, 2, 3]).toString(),
+      equals('DBusArray.uint32([1, 2, 3])'),
+    );
+    expect(
+      DBusArray.int64([1, 2, -3]).toString(),
+      equals('DBusArray.int64([1, 2, -3])'),
+    );
+    expect(
+      DBusArray.uint64([1, 2, 3]).toString(),
+      equals('DBusArray.uint64([1, 2, 3])'),
+    );
+    expect(
+      DBusArray.double([1.1, 2.1, 3.1]).toString(),
+      equals('DBusArray.double([1.1, 2.1, 3.1])'),
+    );
+    expect(
+      DBusArray.string(['one', 'two', 'three']).toString(),
+      equals("DBusArray.string(['one', 'two', 'three'])"),
+    );
+    expect(
+      DBusArray.objectPath([
+        DBusObjectPath('/one'),
+        DBusObjectPath('/two'),
+        DBusObjectPath('/three'),
+      ]).toString(),
+      equals(
+        "DBusArray.objectPath([DBusObjectPath('/one'), DBusObjectPath('/two'), DBusObjectPath('/three')])",
+      ),
+    );
+    expect(
+      DBusArray.signature([DBusSignature('u'), DBusSignature('as')]).toString(),
+      equals("DBusArray.signature([DBusSignature('u'), DBusSignature('as')])"),
+    );
+    expect(
+      DBusArray.variant([
+        DBusInt32(1),
+        DBusString('two'),
+        DBusDouble(3.14159),
+      ]).toString(),
+      equals(
+        "DBusArray.variant([DBusInt32(1), DBusString('two'), DBusDouble(3.14159)])",
+      ),
+    );
+    expect(
+      DBusArray.variant([
+        DBusInt32(1),
+        DBusString('two'),
+        DBusDouble(3.14159),
+      ]).signature,
+      equals(DBusSignature.array(DBusSignature.variant)),
+    );
+    expect(
+      DBusArray.unixFd([stdinHandle, stdoutHandle]).toString(),
+      equals(
+        "DBusArray.unixFd([Instance of '_ResourceHandleImpl', Instance of '_ResourceHandleImpl'])",
+      ),
+    );
+    expect(
+      DBusArray.unixFd([stdinHandle, stdoutHandle]).signature,
+      equals(DBusSignature.array(DBusSignature.unixFd)),
+    );
+    expect(
+      DBusArray.string(['one', 'two', 'three']).hashCode,
+      equals(DBusArray.string(['one', 'two', 'three']).hashCode),
+    );
   });
 
   test('value - dict', () async {
-    expect(DBusDict(DBusSignature('i'), DBusSignature('s'), {}).children,
-        equals({}));
     expect(
-        DBusDict(DBusSignature('i'), DBusSignature('s'), {
-          DBusInt32(1): DBusString('one'),
-          DBusInt32(2): DBusString('two'),
-          DBusInt32(3): DBusString('three')
-        }).children,
-        equals({
-          DBusInt32(1): DBusString('one'),
-          DBusInt32(2): DBusString('two'),
-          DBusInt32(3): DBusString('three')
-        }));
+      DBusDict(DBusSignature('i'), DBusSignature('s'), {}).children,
+      equals({}),
+    );
     expect(
-        DBusDict(DBusSignature('i'), DBusSignature('s'), {
-          DBusInt32(1): DBusString('one'),
-          DBusInt32(2): DBusString('two'),
-          DBusInt32(3): DBusString('three')
-        }).children,
-        equals({
-          DBusInt32(1): DBusString('one'),
-          DBusInt32(2): DBusString('two'),
-          DBusInt32(3): DBusString('three')
-        }));
+      DBusDict(DBusSignature('i'), DBusSignature('s'), {
+        DBusInt32(1): DBusString('one'),
+        DBusInt32(2): DBusString('two'),
+        DBusInt32(3): DBusString('three'),
+      }).children,
+      equals({
+        DBusInt32(1): DBusString('one'),
+        DBusInt32(2): DBusString('two'),
+        DBusInt32(3): DBusString('three'),
+      }),
+    );
+    expect(
+      DBusDict(DBusSignature('i'), DBusSignature('s'), {
+        DBusInt32(1): DBusString('one'),
+        DBusInt32(2): DBusString('two'),
+        DBusInt32(3): DBusString('three'),
+      }).children,
+      equals({
+        DBusInt32(1): DBusString('one'),
+        DBusInt32(2): DBusString('two'),
+        DBusInt32(3): DBusString('three'),
+      }),
+    );
     // Unchecked constructor equivalent to standard constructor.
     expect(
-        DBusDict.unchecked(DBusSignature('i'), DBusSignature('s'), {
+      DBusDict.unchecked(DBusSignature('i'), DBusSignature('s'), {
+        DBusInt32(1): DBusString('one'),
+        DBusInt32(2): DBusString('two'),
+        DBusInt32(3): DBusString('three'),
+      }),
+      equals(
+        DBusDict(DBusSignature('i'), DBusSignature('s'), {
           DBusInt32(1): DBusString('one'),
           DBusInt32(2): DBusString('two'),
-          DBusInt32(3): DBusString('three')
+          DBusInt32(3): DBusString('three'),
         }),
-        equals(DBusDict(DBusSignature('i'), DBusSignature('s'), {
-          DBusInt32(1): DBusString('one'),
-          DBusInt32(2): DBusString('two'),
-          DBusInt32(3): DBusString('three')
-        })));
+      ),
+    );
     // Keys that don't match signature.
     expect(
-        () => DBusDict(DBusSignature('i'), DBusSignature('s'), {
-              DBusInt32(1): DBusString('one'),
-              DBusUint32(2): DBusString('two'),
-              DBusInt32(3): DBusString('three')
-            }),
-        throwsArgumentError);
+      () => DBusDict(DBusSignature('i'), DBusSignature('s'), {
+        DBusInt32(1): DBusString('one'),
+        DBusUint32(2): DBusString('two'),
+        DBusInt32(3): DBusString('three'),
+      }),
+      throwsArgumentError,
+    );
     // Values that don't match signature.
     expect(
-        () => DBusDict(DBusSignature('i'), DBusSignature('s'), {
-              DBusInt32(1): DBusString('one'),
-              DBusInt32(2): DBusUint32(2),
-              DBusInt32(3): DBusString('three')
-            }),
-        throwsArgumentError);
+      () => DBusDict(DBusSignature('i'), DBusSignature('s'), {
+        DBusInt32(1): DBusString('one'),
+        DBusInt32(2): DBusUint32(2),
+        DBusInt32(3): DBusString('three'),
+      }),
+      throwsArgumentError,
+    );
     // Only single types are allowed as keys.
-    expect(() => DBusDict(DBusSignature('ii'), DBusSignature('s'), {}),
-        throwsArgumentError);
+    expect(
+      () => DBusDict(DBusSignature('ii'), DBusSignature('s'), {}),
+      throwsArgumentError,
+    );
     // Value must be a complete type.
-    expect(() => DBusDict(DBusSignature('s'), DBusSignature('ss'), {}),
-        throwsArgumentError);
-    expect(DBusDict(DBusSignature('i'), DBusSignature('s'), {}).keySignature,
-        equals(DBusSignature('i')));
-    expect(DBusDict(DBusSignature('i'), DBusSignature('s'), {}).valueSignature,
-        equals(DBusSignature('s')));
-    expect(DBusDict(DBusSignature('i'), DBusSignature('s'), {}).signature,
-        equals(DBusSignature('a{is}')));
     expect(
-        DBusDict(DBusSignature('i'), DBusSignature('s'), {
-          DBusInt32(1): DBusString('one'),
-          DBusInt32(2): DBusString('two'),
-          DBusInt32(3): DBusString('three')
-        }).asDict(),
-        equals({
-          DBusInt32(1): DBusString('one'),
-          DBusInt32(2): DBusString('two'),
-          DBusInt32(3): DBusString('three')
-        }));
+      () => DBusDict(DBusSignature('s'), DBusSignature('ss'), {}),
+      throwsArgumentError,
+    );
     expect(
-        DBusDict(DBusSignature('i'), DBusSignature('s'), {
-          DBusInt32(1): DBusString('one'),
-          DBusInt32(2): DBusString('two'),
-          DBusInt32(3): DBusString('three')
-        }).toNative(),
-        equals({1: 'one', 2: 'two', 3: 'three'}));
+      DBusDict(DBusSignature('i'), DBusSignature('s'), {}).keySignature,
+      equals(DBusSignature('i')),
+    );
     expect(
-        DBusDict(DBusSignature('i'), DBusSignature('s'), {
-              DBusInt32(1): DBusString('one'),
-              DBusInt32(2): DBusString('two'),
-              DBusInt32(3): DBusString('three')
-            }) ==
-            DBusDict(DBusSignature('i'), DBusSignature('s'), {
-              DBusInt32(1): DBusString('one'),
-              DBusInt32(2): DBusString('two'),
-              DBusInt32(3): DBusString('three')
-            }),
-        isTrue);
+      DBusDict(DBusSignature('i'), DBusSignature('s'), {}).valueSignature,
+      equals(DBusSignature('s')),
+    );
     expect(
-        DBusDict(DBusSignature('i'), DBusSignature('s'), {
-              DBusInt32(1): DBusString('one'),
-              DBusInt32(2): DBusString('two'),
-              DBusInt32(3): DBusString('three')
-            }) ==
-            DBusDict(DBusSignature('i'), DBusSignature('s'), {
-              DBusInt32(1): DBusString('three'),
-              DBusInt32(2): DBusString('two'),
-              DBusInt32(3): DBusString('one')
-            }),
-        isFalse);
+      DBusDict(DBusSignature('i'), DBusSignature('s'), {}).signature,
+      equals(DBusSignature('a{is}')),
+    );
+    expect(
+      DBusDict(DBusSignature('i'), DBusSignature('s'), {
+        DBusInt32(1): DBusString('one'),
+        DBusInt32(2): DBusString('two'),
+        DBusInt32(3): DBusString('three'),
+      }).asDict(),
+      equals({
+        DBusInt32(1): DBusString('one'),
+        DBusInt32(2): DBusString('two'),
+        DBusInt32(3): DBusString('three'),
+      }),
+    );
+    expect(
+      DBusDict(DBusSignature('i'), DBusSignature('s'), {
+        DBusInt32(1): DBusString('one'),
+        DBusInt32(2): DBusString('two'),
+        DBusInt32(3): DBusString('three'),
+      }).toNative(),
+      equals({1: 'one', 2: 'two', 3: 'three'}),
+    );
+    expect(
+      DBusDict(DBusSignature('i'), DBusSignature('s'), {
+            DBusInt32(1): DBusString('one'),
+            DBusInt32(2): DBusString('two'),
+            DBusInt32(3): DBusString('three'),
+          }) ==
+          DBusDict(DBusSignature('i'), DBusSignature('s'), {
+            DBusInt32(1): DBusString('one'),
+            DBusInt32(2): DBusString('two'),
+            DBusInt32(3): DBusString('three'),
+          }),
+      isTrue,
+    );
+    expect(
+      DBusDict(DBusSignature('i'), DBusSignature('s'), {
+            DBusInt32(1): DBusString('one'),
+            DBusInt32(2): DBusString('two'),
+            DBusInt32(3): DBusString('three'),
+          }) ==
+          DBusDict(DBusSignature('i'), DBusSignature('s'), {
+            DBusInt32(1): DBusString('three'),
+            DBusInt32(2): DBusString('two'),
+            DBusInt32(3): DBusString('one'),
+          }),
+      isFalse,
+    );
     // Check factory constructors are equivalent to their full expansions.
     expect(
-        DBusDict.stringVariant({'one': DBusInt32(1), 'two': DBusDouble(2)}),
-        equals(DBusDict(DBusSignature('s'), DBusSignature('v'), {
+      DBusDict.stringVariant({'one': DBusInt32(1), 'two': DBusDouble(2)}),
+      equals(
+        DBusDict(DBusSignature('s'), DBusSignature('v'), {
           DBusString('one'): DBusVariant(DBusInt32(1)),
-          DBusString('two'): DBusVariant(DBusDouble(2))
-        })));
+          DBusString('two'): DBusVariant(DBusDouble(2)),
+        }),
+      ),
+    );
     expect(
-        DBusDict.stringVariant({'one': DBusInt32(1), 'two': DBusDouble(2)})
-            .asStringVariantDict(),
-        equals({'one': DBusInt32(1), 'two': DBusDouble(2)}));
+      DBusDict.stringVariant({
+        'one': DBusInt32(1),
+        'two': DBusDouble(2),
+      }).asStringVariantDict(),
+      equals({'one': DBusInt32(1), 'two': DBusDouble(2)}),
+    );
     expect(
-        DBusDict(DBusSignature('i'), DBusSignature('s'), {
-          DBusInt32(1): DBusString('one'),
-          DBusInt32(2): DBusString('two'),
-          DBusInt32(3): DBusString('three')
-        }).toString(),
-        equals(
-            "DBusDict(DBusSignature('i'), DBusSignature('s'), {DBusInt32(1): DBusString('one'), DBusInt32(2): DBusString('two'), DBusInt32(3): DBusString('three')})"));
+      DBusDict(DBusSignature('i'), DBusSignature('s'), {
+        DBusInt32(1): DBusString('one'),
+        DBusInt32(2): DBusString('two'),
+        DBusInt32(3): DBusString('three'),
+      }).toString(),
+      equals(
+        "DBusDict(DBusSignature('i'), DBusSignature('s'), {DBusInt32(1): DBusString('one'), DBusInt32(2): DBusString('two'), DBusInt32(3): DBusString('three')})",
+      ),
+    );
     expect(
-        DBusDict.stringVariant({'one': DBusInt32(1), 'two': DBusDouble(2)})
-            .toString(),
-        equals(
-            "DBusDict.stringVariant({'one': DBusInt32(1), 'two': DBusDouble(2.0)})"));
+      DBusDict.stringVariant({
+        'one': DBusInt32(1),
+        'two': DBusDouble(2),
+      }).toString(),
+      equals(
+        "DBusDict.stringVariant({'one': DBusInt32(1), 'two': DBusDouble(2.0)})",
+      ),
+    );
     expect(
-        DBusDict.stringVariant({'one': DBusInt32(1), 'two': DBusDouble(2)})
-            .signature,
-        equals(
-            DBusSignature.dict(DBusSignature.string, DBusSignature.variant)));
+      DBusDict.stringVariant({
+        'one': DBusInt32(1),
+        'two': DBusDouble(2),
+      }).signature,
+      equals(DBusSignature.dict(DBusSignature.string, DBusSignature.variant)),
+    );
     expect(
-        DBusDict.stringVariant({'one': DBusInt32(1), 'two': DBusDouble(2)})
-            .hashCode,
-        equals(
-            DBusDict.stringVariant({'one': DBusInt32(1), 'two': DBusDouble(2)})
-                .hashCode));
+      DBusDict.stringVariant({
+        'one': DBusInt32(1),
+        'two': DBusDouble(2),
+      }).hashCode,
+      equals(
+        DBusDict.stringVariant({
+          'one': DBusInt32(1),
+          'two': DBusDouble(2),
+        }).hashCode,
+      ),
+    );
   });
 
   test('uuid', () async {
     expect(
-        DBusUUID.fromHexString('a61fb428740a11ec90d60242ac120003').value,
-        equals([
-          0xa6,
-          0x1f,
-          0xb4,
-          0x28,
-          0x74,
-          0x0a,
-          0x11,
-          0xec,
-          0x90,
-          0xd6,
-          0x02,
-          0x42,
-          0xac,
-          0x12,
-          0x00,
-          0x03
-        ]));
+      DBusUUID.fromHexString('a61fb428740a11ec90d60242ac120003').value,
+      equals([
+        0xa6,
+        0x1f,
+        0xb4,
+        0x28,
+        0x74,
+        0x0a,
+        0x11,
+        0xec,
+        0x90,
+        0xd6,
+        0x02,
+        0x42,
+        0xac,
+        0x12,
+        0x00,
+        0x03,
+      ]),
+    );
     expect(
-        DBusUUID.fromHexString('a61fb428740a11ec90d60242ac120003')
-            .toHexString(),
-        equals('a61fb428740a11ec90d60242ac120003'));
-    expect(() => DBusUUID.fromHexString('a61fb428-740a-11ec-90d6-0242ac120003'),
-        throwsFormatException);
+      DBusUUID.fromHexString('a61fb428740a11ec90d60242ac120003').toHexString(),
+      equals('a61fb428740a11ec90d60242ac120003'),
+    );
+    expect(
+      () => DBusUUID.fromHexString('a61fb428-740a-11ec-90d6-0242ac120003'),
+      throwsFormatException,
+    );
   });
 
   test('address', () async {
@@ -1109,8 +1387,10 @@ void main() {
     expect(address.properties, equals({'key': '😄'}));
 
     // Address created from raw values.
-    address = DBusAddress.withTransport(
-        'transport', {'key1': 'value1', 'key2': 'value2'});
+    address = DBusAddress.withTransport('transport', {
+      'key1': 'value1',
+      'key2': 'value2',
+    });
     expect(address.value, equals('transport:key1=value1,key2=value2'));
 
     // Properties with escaped values.
@@ -1125,29 +1405,40 @@ void main() {
     address = DBusAddress.unix();
     expect(address.value, equals('unix:'));
     address = DBusAddress.unix(
-        path: '/path',
-        dir: Directory('/dir'),
-        tmpdir: Directory('/tmp'),
-        abstract: 'foo',
-        runtime: true);
+      path: '/path',
+      dir: Directory('/dir'),
+      tmpdir: Directory('/tmp'),
+      abstract: 'foo',
+      runtime: true,
+    );
     expect(
-        address.value,
-        equals(
-            'unix:path=/path,dir=/dir,tmpdir=/tmp,abstract=foo,runtime=yes'));
-    expect(DBusAddress.unix(path: '/path').toString(),
-        equals("DBusAddress('unix:path=/path')"));
+      address.value,
+      equals('unix:path=/path,dir=/dir,tmpdir=/tmp,abstract=foo,runtime=yes'),
+    );
+    expect(
+      DBusAddress.unix(path: '/path').toString(),
+      equals("DBusAddress('unix:path=/path')"),
+    );
 
     // TCP addresses.
     address = DBusAddress.tcp('example.com');
     expect(address.value, equals('tcp:host=example.com'));
-    address = DBusAddress.tcp('example.com',
-        bind: '192.168.1.1', port: 42, family: DBusAddressTcpFamily.ipv4);
-    expect(address.value,
-        equals('tcp:host=example.com,bind=192.168.1.1,port=42,family=ipv4'));
+    address = DBusAddress.tcp(
+      'example.com',
+      bind: '192.168.1.1',
+      port: 42,
+      family: DBusAddressTcpFamily.ipv4,
+    );
+    expect(
+      address.value,
+      equals('tcp:host=example.com,bind=192.168.1.1,port=42,family=ipv4'),
+    );
     address = DBusAddress.tcp('example.com', family: DBusAddressTcpFamily.ipv6);
     expect(address.value, equals('tcp:host=example.com,family=ipv6'));
-    expect(DBusAddress.tcp('example.com').toString(),
-        equals("DBusAddress('tcp:host=example.com')"));
+    expect(
+      DBusAddress.tcp('example.com').toString(),
+      equals("DBusAddress('tcp:host=example.com')"),
+    );
   });
 
   test('bus name', () async {
@@ -1160,63 +1451,94 @@ void main() {
     expect(() => DBusBusName(''), throwsFormatException);
     expect(() => DBusBusName('com'), throwsFormatException);
     expect(DBusBusName('com.example').value, equals('com.example'));
-    expect(DBusBusName('com.example.${'X' * 243}').value,
-        equals('com.example.${'X' * 243}'));
     expect(
-        () => DBusBusName('com.example.${'X' * 244}'), throwsFormatException);
+      DBusBusName('com.example.${'X' * 243}').value,
+      equals('com.example.${'X' * 243}'),
+    );
+    expect(
+      () => DBusBusName('com.example.${'X' * 244}'),
+      throwsFormatException,
+    );
     expect(() => DBusBusName('com.example.Test~1'), throwsFormatException);
-    expect(DBusBusName('com.example.Test') == DBusBusName('com.example.Test'),
-        isTrue);
-    expect(DBusBusName('com.example.Test1') == DBusBusName('com.example.Test2'),
-        isFalse);
-    expect(DBusBusName('com.example.Test').toString(),
-        equals("DBusBusName('com.example.Test')"));
+    expect(
+      DBusBusName('com.example.Test') == DBusBusName('com.example.Test'),
+      isTrue,
+    );
+    expect(
+      DBusBusName('com.example.Test1') == DBusBusName('com.example.Test2'),
+      isFalse,
+    );
+    expect(
+      DBusBusName('com.example.Test').toString(),
+      equals("DBusBusName('com.example.Test')"),
+    );
   });
 
   test('interface name', () async {
-    expect(DBusInterfaceName('com.example.Test').value,
-        equals('com.example.Test'));
+    expect(
+      DBusInterfaceName('com.example.Test').value,
+      equals('com.example.Test'),
+    );
     expect(() => DBusInterfaceName(''), throwsFormatException);
     expect(() => DBusInterfaceName('com'), throwsFormatException);
     expect(DBusInterfaceName('com.example').value, equals('com.example'));
-    expect(DBusInterfaceName('com.example.${'X' * 243}').value,
-        equals('com.example.${'X' * 243}'));
-    expect(() => DBusInterfaceName('com.example.${'X' * 244}'),
-        throwsFormatException);
     expect(
-        () => DBusInterfaceName('com.example.Test~1'), throwsFormatException);
+      DBusInterfaceName('com.example.${'X' * 243}').value,
+      equals('com.example.${'X' * 243}'),
+    );
     expect(
-        DBusInterfaceName('com.example.Test') ==
-            DBusInterfaceName('com.example.Test'),
-        isTrue);
+      () => DBusInterfaceName('com.example.${'X' * 244}'),
+      throwsFormatException,
+    );
     expect(
-        DBusInterfaceName('com.example.Test1') ==
-            DBusInterfaceName('com.example.Test2'),
-        isFalse);
-    expect(DBusInterfaceName('com.example.Test').toString(),
-        equals("DBusInterfaceName('com.example.Test')"));
+      () => DBusInterfaceName('com.example.Test~1'),
+      throwsFormatException,
+    );
+    expect(
+      DBusInterfaceName('com.example.Test') ==
+          DBusInterfaceName('com.example.Test'),
+      isTrue,
+    );
+    expect(
+      DBusInterfaceName('com.example.Test1') ==
+          DBusInterfaceName('com.example.Test2'),
+      isFalse,
+    );
+    expect(
+      DBusInterfaceName('com.example.Test').toString(),
+      equals("DBusInterfaceName('com.example.Test')"),
+    );
   });
 
   test('error name', () async {
     expect(
-        DBusErrorName('com.example.Error').value, equals('com.example.Error'));
+      DBusErrorName('com.example.Error').value,
+      equals('com.example.Error'),
+    );
     expect(() => DBusErrorName(''), throwsFormatException);
     expect(() => DBusErrorName('com'), throwsFormatException);
     expect(DBusErrorName('com.example').value, equals('com.example'));
-    expect(DBusErrorName('com.example.${'X' * 243}').value,
-        equals('com.example.${'X' * 243}'));
     expect(
-        () => DBusErrorName('com.example.${'X' * 244}'), throwsFormatException);
+      DBusErrorName('com.example.${'X' * 243}').value,
+      equals('com.example.${'X' * 243}'),
+    );
+    expect(
+      () => DBusErrorName('com.example.${'X' * 244}'),
+      throwsFormatException,
+    );
     expect(() => DBusErrorName('com.example.Test~1'), throwsFormatException);
     expect(
-        DBusErrorName('com.example.Test') == DBusErrorName('com.example.Test'),
-        isTrue);
+      DBusErrorName('com.example.Test') == DBusErrorName('com.example.Test'),
+      isTrue,
+    );
     expect(
-        DBusErrorName('com.example.Test1') ==
-            DBusErrorName('com.example.Test2'),
-        isFalse);
-    expect(DBusErrorName('com.example.Test').toString(),
-        equals("DBusErrorName('com.example.Test')"));
+      DBusErrorName('com.example.Test1') == DBusErrorName('com.example.Test2'),
+      isFalse,
+    );
+    expect(
+      DBusErrorName('com.example.Test').toString(),
+      equals("DBusErrorName('com.example.Test')"),
+    );
   });
 
   test('member name', () async {
@@ -1227,8 +1549,10 @@ void main() {
     expect(() => DBusMemberName('Member~1'), throwsFormatException);
     expect(DBusMemberName('Member') == DBusMemberName('Member'), isTrue);
     expect(DBusMemberName('Member1') == DBusMemberName('Member2'), isFalse);
-    expect(DBusMemberName('Member').toString(),
-        equals("DBusMemberName('Member')"));
+    expect(
+      DBusMemberName('Member').toString(),
+      equals("DBusMemberName('Member')"),
+    );
   });
 
   test('match rule', () async {
@@ -1244,147 +1568,212 @@ void main() {
 
     // Basic fields.
     var rule2 = DBusMatchRule.fromDBusString(
-        'type=method_call,sender=com.example.Test,interface=com.example.Test.Interface1,member=HelloWorld,path=/com/example/Test/Object1');
+      'type=method_call,sender=com.example.Test,interface=com.example.Test.Interface1,member=HelloWorld,path=/com/example/Test/Object1',
+    );
     expect(rule2.type, equals(DBusMessageType.methodCall));
     expect(rule2.sender, equals(DBusBusName('com.example.Test')));
-    expect(rule2.interface,
-        equals(DBusInterfaceName('com.example.Test.Interface1')));
+    expect(
+      rule2.interface,
+      equals(DBusInterfaceName('com.example.Test.Interface1')),
+    );
     expect(rule2.member, equals(DBusMemberName('HelloWorld')));
     expect(rule2.path, equals(DBusObjectPath('/com/example/Test/Object1')));
     expect(
-        rule2.toString(),
-        equals(
-            "DBusMatchRule(type=DBusMessageType.methodCall, sender=DBusBusName('com.example.Test'), interface=DBusInterfaceName('com.example.Test.Interface1'), member=DBusMemberName('HelloWorld'), path=DBusObjectPath('/com/example/Test/Object1'))"));
+      rule2.toString(),
+      equals(
+        "DBusMatchRule(type=DBusMessageType.methodCall, sender=DBusBusName('com.example.Test'), interface=DBusInterfaceName('com.example.Test.Interface1'), member=DBusMemberName('HelloWorld'), path=DBusObjectPath('/com/example/Test/Object1'))",
+      ),
+    );
 
     // Comma between fields.
     expect(
-        () => DBusMatchRule.fromDBusString(
-            "type='method_call'sender='com.example.Test'"),
-        throwsA(isA<DBusMatchRuleException>()));
+      () => DBusMatchRule.fromDBusString(
+        "type='method_call'sender='com.example.Test'",
+      ),
+      throwsA(isA<DBusMatchRuleException>()),
+    );
     expect(
-        () => DBusMatchRule.fromDBusString(
-            "type='method_call' sender='com.example.Test'"),
-        throwsA(isA<DBusMatchRuleException>()));
+      () => DBusMatchRule.fromDBusString(
+        "type='method_call' sender='com.example.Test'",
+      ),
+      throwsA(isA<DBusMatchRuleException>()),
+    );
     expect(
-        () => DBusMatchRule.fromDBusString(
-            "type='method_call';sender='com.example.Test'"),
-        throwsA(isA<DBusMatchRuleException>()));
-    expect(() => DBusMatchRule.fromDBusString(',type=method_call'),
-        throwsA(isA<DBusMatchRuleException>()));
-    expect(() => DBusMatchRule.fromDBusString('type=method_call,'),
-        throwsA(isA<DBusMatchRuleException>()));
+      () => DBusMatchRule.fromDBusString(
+        "type='method_call';sender='com.example.Test'",
+      ),
+      throwsA(isA<DBusMatchRuleException>()),
+    );
+    expect(
+      () => DBusMatchRule.fromDBusString(',type=method_call'),
+      throwsA(isA<DBusMatchRuleException>()),
+    );
+    expect(
+      () => DBusMatchRule.fromDBusString('type=method_call,'),
+      throwsA(isA<DBusMatchRuleException>()),
+    );
 
     // Path namespaces.
     var rule3 = DBusMatchRule.fromDBusString(
-        'type=signal,path_namespace=/com/example/Test');
+      'type=signal,path_namespace=/com/example/Test',
+    );
     expect(rule3.pathNamespace, equals(DBusObjectPath('/com/example/Test')));
     expect(
-        () => DBusMatchRule.fromDBusString(
-            'path=/com/example/Test/Object1,path_namespace=/com/example/Test'),
-        throwsA(isA<DBusMatchRuleException>()));
+      () => DBusMatchRule.fromDBusString(
+        'path=/com/example/Test/Object1,path_namespace=/com/example/Test',
+      ),
+      throwsA(isA<DBusMatchRuleException>()),
+    );
 
     // Quotes.
-    expect(DBusMatchRule.fromDBusString('sender=com.example.Test').sender,
-        equals(DBusBusName('com.example.Test')));
-    expect(DBusMatchRule.fromDBusString("sender='com.example.Test'").sender,
-        equals(DBusBusName('com.example.Test')));
     expect(
-        () => DBusMatchRule.fromDBusString(
-            "arg0=''\\''',arg1='\\',arg2=',',arg3='\\\\'"),
-        returnsNormally);
+      DBusMatchRule.fromDBusString('sender=com.example.Test').sender,
+      equals(DBusBusName('com.example.Test')),
+    );
     expect(
-        () =>
-            DBusMatchRule.fromDBusString("arg0=\\',arg1=\\,arg2=',',arg3=\\\\"),
-        returnsNormally);
-    expect(() => DBusMatchRule.fromDBusString("key='''"),
-        throwsA(isA<DBusMatchRuleException>()));
-    expect(() => DBusMatchRule.fromDBusString("key='value"),
-        throwsA(isA<DBusMatchRuleException>()));
-    expect(() => DBusMatchRule.fromDBusString("key=value'"),
-        throwsA(isA<DBusMatchRuleException>()));
+      DBusMatchRule.fromDBusString("sender='com.example.Test'").sender,
+      equals(DBusBusName('com.example.Test')),
+    );
+    expect(
+      () => DBusMatchRule.fromDBusString(
+        "arg0=''\\''',arg1='\\',arg2=',',arg3='\\\\'",
+      ),
+      returnsNormally,
+    );
+    expect(
+      () => DBusMatchRule.fromDBusString("arg0=\\',arg1=\\,arg2=',',arg3=\\\\"),
+      returnsNormally,
+    );
+    expect(
+      () => DBusMatchRule.fromDBusString("key='''"),
+      throwsA(isA<DBusMatchRuleException>()),
+    );
+    expect(
+      () => DBusMatchRule.fromDBusString("key='value"),
+      throwsA(isA<DBusMatchRuleException>()),
+    );
+    expect(
+      () => DBusMatchRule.fromDBusString("key=value'"),
+      throwsA(isA<DBusMatchRuleException>()),
+    );
 
     // Value required
-    expect(() => DBusMatchRule.fromDBusString('key1,key2=value2'),
-        throwsA(isA<DBusMatchRuleException>()));
-    expect(() => DBusMatchRule.fromDBusString('key1=value1,key2'),
-        throwsA(isA<DBusMatchRuleException>()));
+    expect(
+      () => DBusMatchRule.fromDBusString('key1,key2=value2'),
+      throwsA(isA<DBusMatchRuleException>()),
+    );
+    expect(
+      () => DBusMatchRule.fromDBusString('key1=value1,key2'),
+      throwsA(isA<DBusMatchRuleException>()),
+    );
 
     // Valid types.
-    expect(DBusMatchRule.fromDBusString("type='signal'").type,
-        equals(DBusMessageType.signal));
-    expect(DBusMatchRule.fromDBusString("type='method_call'").type,
-        equals(DBusMessageType.methodCall));
-    expect(DBusMatchRule.fromDBusString("type='method_return'").type,
-        equals(DBusMessageType.methodReturn));
-    expect(DBusMatchRule.fromDBusString("type='error'").type,
-        equals(DBusMessageType.error));
-    expect(() => DBusMatchRule.fromDBusString("type='invalid_type'"),
-        throwsA(isA<DBusMatchRuleException>()));
+    expect(
+      DBusMatchRule.fromDBusString("type='signal'").type,
+      equals(DBusMessageType.signal),
+    );
+    expect(
+      DBusMatchRule.fromDBusString("type='method_call'").type,
+      equals(DBusMessageType.methodCall),
+    );
+    expect(
+      DBusMatchRule.fromDBusString("type='method_return'").type,
+      equals(DBusMessageType.methodReturn),
+    );
+    expect(
+      DBusMatchRule.fromDBusString("type='error'").type,
+      equals(DBusMessageType.error),
+    );
+    expect(
+      () => DBusMatchRule.fromDBusString("type='invalid_type'"),
+      throwsA(isA<DBusMatchRuleException>()),
+    );
   });
 
   test('message', () async {
-    expect(DBusMessage(DBusMessageType.methodCall).toString(),
-        equals('DBusMessage(type: DBusMessageType.methodCall, serial: 0)'));
+    expect(
+      DBusMessage(DBusMessageType.methodCall).toString(),
+      equals('DBusMessage(type: DBusMessageType.methodCall, serial: 0)'),
+    );
 
     expect(
-        DBusMessage(DBusMessageType.methodCall,
-            flags: {DBusMessageFlag.noAutoStart},
-            serial: 1234,
-            path: DBusObjectPath('/com/example/Test/Object'),
-            interface: DBusInterfaceName('com.example.Test.Interface1'),
-            member: DBusMemberName('Hello'),
-            destination: DBusBusName('com.example.Test2'),
-            sender: DBusBusName('com.example.Test'),
-            values: [DBusString('Ping')]).toString(),
-        equals(
-            "DBusMessage(type: DBusMessageType.methodCall, flags: {DBusMessageFlag.noAutoStart}, serial: 1234, path: DBusObjectPath('/com/example/Test/Object'), interface: DBusInterfaceName('com.example.Test.Interface1'), member: DBusMemberName('Hello'), destination: DBusBusName('com.example.Test2'), sender: DBusBusName('com.example.Test'), values: [DBusString('Ping')])"));
+      DBusMessage(
+        DBusMessageType.methodCall,
+        flags: {DBusMessageFlag.noAutoStart},
+        serial: 1234,
+        path: DBusObjectPath('/com/example/Test/Object'),
+        interface: DBusInterfaceName('com.example.Test.Interface1'),
+        member: DBusMemberName('Hello'),
+        destination: DBusBusName('com.example.Test2'),
+        sender: DBusBusName('com.example.Test'),
+        values: [DBusString('Ping')],
+      ).toString(),
+      equals(
+        "DBusMessage(type: DBusMessageType.methodCall, flags: {DBusMessageFlag.noAutoStart}, serial: 1234, path: DBusObjectPath('/com/example/Test/Object'), interface: DBusInterfaceName('com.example.Test.Interface1'), member: DBusMemberName('Hello'), destination: DBusBusName('com.example.Test2'), sender: DBusBusName('com.example.Test'), values: [DBusString('Ping')])",
+      ),
+    );
 
     expect(
-        DBusMessage(DBusMessageType.methodReturn,
-            flags: {DBusMessageFlag.noReplyExpected},
-            serial: 1235,
-            replySerial: 1234,
-            destination: DBusBusName('com.example.Test1'),
-            sender: DBusBusName('com.example.Test2'),
-            values: [DBusString('Pong')]).toString(),
-        equals(
-            "DBusMessage(type: DBusMessageType.methodReturn, flags: {DBusMessageFlag.noReplyExpected}, serial: 1235, replySerial: 1234, destination: DBusBusName('com.example.Test1'), sender: DBusBusName('com.example.Test2'), values: [DBusString('Pong')])"));
+      DBusMessage(
+        DBusMessageType.methodReturn,
+        flags: {DBusMessageFlag.noReplyExpected},
+        serial: 1235,
+        replySerial: 1234,
+        destination: DBusBusName('com.example.Test1'),
+        sender: DBusBusName('com.example.Test2'),
+        values: [DBusString('Pong')],
+      ).toString(),
+      equals(
+        "DBusMessage(type: DBusMessageType.methodReturn, flags: {DBusMessageFlag.noReplyExpected}, serial: 1235, replySerial: 1234, destination: DBusBusName('com.example.Test1'), sender: DBusBusName('com.example.Test2'), values: [DBusString('Pong')])",
+      ),
+    );
 
     expect(
-        DBusMessage(DBusMessageType.error,
-            flags: {DBusMessageFlag.noReplyExpected},
-            serial: 1235,
-            errorName: DBusErrorName('com.example.Test.Error1'),
-            replySerial: 1234,
-            destination: DBusBusName('com.example.Test1'),
-            sender: DBusBusName('com.example.Test2'),
-            values: [DBusString('Error description')]).toString(),
-        equals(
-            "DBusMessage(type: DBusMessageType.error, flags: {DBusMessageFlag.noReplyExpected}, serial: 1235, errorName: DBusErrorName('com.example.Test.Error1'), replySerial: 1234, destination: DBusBusName('com.example.Test1'), sender: DBusBusName('com.example.Test2'), values: [DBusString('Error description')])"));
+      DBusMessage(
+        DBusMessageType.error,
+        flags: {DBusMessageFlag.noReplyExpected},
+        serial: 1235,
+        errorName: DBusErrorName('com.example.Test.Error1'),
+        replySerial: 1234,
+        destination: DBusBusName('com.example.Test1'),
+        sender: DBusBusName('com.example.Test2'),
+        values: [DBusString('Error description')],
+      ).toString(),
+      equals(
+        "DBusMessage(type: DBusMessageType.error, flags: {DBusMessageFlag.noReplyExpected}, serial: 1235, errorName: DBusErrorName('com.example.Test.Error1'), replySerial: 1234, destination: DBusBusName('com.example.Test1'), sender: DBusBusName('com.example.Test2'), values: [DBusString('Error description')])",
+      ),
+    );
 
     expect(
-        DBusMessage(DBusMessageType.signal,
-            flags: {DBusMessageFlag.noReplyExpected},
-            serial: 1236,
-            path: DBusObjectPath('/com/example/Test/Object'),
-            interface: DBusInterfaceName('com.example.Test.Interface1'),
-            member: DBusMemberName('Event'),
-            destination: DBusBusName('com.example.Test1'),
-            sender: DBusBusName('com.example.Test2'),
-            values: [DBusString('Boo')]).toString(),
-        equals(
-            "DBusMessage(type: DBusMessageType.signal, flags: {DBusMessageFlag.noReplyExpected}, serial: 1236, path: DBusObjectPath('/com/example/Test/Object'), interface: DBusInterfaceName('com.example.Test.Interface1'), member: DBusMemberName('Event'), destination: DBusBusName('com.example.Test1'), sender: DBusBusName('com.example.Test2'), values: [DBusString('Boo')])"));
+      DBusMessage(
+        DBusMessageType.signal,
+        flags: {DBusMessageFlag.noReplyExpected},
+        serial: 1236,
+        path: DBusObjectPath('/com/example/Test/Object'),
+        interface: DBusInterfaceName('com.example.Test.Interface1'),
+        member: DBusMemberName('Event'),
+        destination: DBusBusName('com.example.Test1'),
+        sender: DBusBusName('com.example.Test2'),
+        values: [DBusString('Boo')],
+      ).toString(),
+      equals(
+        "DBusMessage(type: DBusMessageType.signal, flags: {DBusMessageFlag.noReplyExpected}, serial: 1236, path: DBusObjectPath('/com/example/Test/Object'), interface: DBusInterfaceName('com.example.Test.Interface1'), member: DBusMemberName('Event'), destination: DBusBusName('com.example.Test1'), sender: DBusBusName('com.example.Test2'), values: [DBusString('Boo')])",
+      ),
+    );
   });
 
   test('method call', () async {
-    expect(DBusMethodCall(sender: 'com.example.Test', name: 'Hello').toString(),
-        equals("DBusMethodCall(sender: 'com.example.Test', name: 'Hello')"));
+    expect(
+      DBusMethodCall(sender: 'com.example.Test', name: 'Hello').toString(),
+      equals("DBusMethodCall(sender: 'com.example.Test', name: 'Hello')"),
+    );
   });
 
   test('ping', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -1397,8 +1786,9 @@ void main() {
 
   test('ping - abstract', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(abstract: 'abstract'));
+    var address = await server.listenAddress(
+      DBusAddress.unix(abstract: 'abstract'),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -1412,7 +1802,8 @@ void main() {
   test('ping - ipv4 tcp', () async {
     var server = DBusServer();
     var address = await server.listenAddress(
-        DBusAddress.tcp('localhost', family: DBusAddressTcpFamily.ipv4));
+      DBusAddress.tcp('localhost', family: DBusAddressTcpFamily.ipv4),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -1435,7 +1826,8 @@ void main() {
 
     var server = DBusServer();
     var address = await server.listenAddress(
-        DBusAddress.tcp('localhost', family: DBusAddressTcpFamily.ipv6));
+      DBusAddress.tcp('localhost', family: DBusAddressTcpFamily.ipv6),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -1448,8 +1840,9 @@ void main() {
 
   test('double hello', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(abstract: 'abstract'));
+    var address = await server.listenAddress(
+      DBusAddress.unix(abstract: 'abstract'),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -1458,18 +1851,21 @@ void main() {
 
     // Can't call hello a second time.
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'Hello'),
-        throwsException);
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'Hello',
+      ),
+      throwsException,
+    );
   });
 
   test('server closed', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(abstract: 'abstract'));
+    var address = await server.listenAddress(
+      DBusAddress.unix(abstract: 'abstract'),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -1487,8 +1883,9 @@ void main() {
 
   test('client closed', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -1509,13 +1906,16 @@ void main() {
 
     // Try and ping the closed client.
     expect(
-        () => client2.ping(name1), throwsA(isA<DBusServiceUnknownException>()));
+      () => client2.ping(name1),
+      throwsA(isA<DBusServiceUnknownException>()),
+    );
   });
 
   test('list names', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -1529,8 +1929,9 @@ void main() {
 
   test('request name', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -1548,9 +1949,15 @@ void main() {
     // Check get events when acquired.
     expect(client.nameAcquired, emits('com.example.Test'));
     expect(
-        client.nameOwnerChanged,
-        emits(DBusNameOwnerChangedEvent('com.example.Test',
-            oldOwner: null, newOwner: client.uniqueName)));
+      client.nameOwnerChanged,
+      emits(
+        DBusNameOwnerChangedEvent(
+          'com.example.Test',
+          oldOwner: null,
+          newOwner: client.uniqueName,
+        ),
+      ),
+    );
 
     // Request the name.
     var reply = await client.requestName('com.example.Test');
@@ -1560,9 +1967,9 @@ void main() {
     expect(client.ownedNames, equals(['com.example.Test']));
     names = await client.listNames();
     expect(
-        names,
-        equals(
-            ['org.freedesktop.DBus', client.uniqueName, 'com.example.Test']));
+      names,
+      equals(['org.freedesktop.DBus', client.uniqueName, 'com.example.Test']),
+    );
     hasOwner = await client.nameHasOwner('com.example.Test');
     expect(hasOwner, isTrue);
     owner = await client.getNameOwner('com.example.Test');
@@ -1573,8 +1980,9 @@ void main() {
 
   test('request name - client closed', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -1588,13 +1996,20 @@ void main() {
 
     // Check name is released when client disconnects.
     expect(
-        client2.nameOwnerChanged,
-        emitsInOrder([
-          DBusNameOwnerChangedEvent('com.example.Test',
-              oldOwner: null, newOwner: client1.uniqueName),
-          DBusNameOwnerChangedEvent('com.example.Test',
-              oldOwner: client1.uniqueName, newOwner: null)
-        ]));
+      client2.nameOwnerChanged,
+      emitsInOrder([
+        DBusNameOwnerChangedEvent(
+          'com.example.Test',
+          oldOwner: null,
+          newOwner: client1.uniqueName,
+        ),
+        DBusNameOwnerChangedEvent(
+          'com.example.Test',
+          oldOwner: client1.uniqueName,
+          newOwner: null,
+        ),
+      ]),
+    );
     await client2.ping();
 
     // Request the name.
@@ -1607,8 +2022,9 @@ void main() {
 
   test('request name - already owned', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -1632,8 +2048,9 @@ void main() {
 
   test('request name - queue', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     var client3 = DBusClient(address);
@@ -1648,9 +2065,15 @@ void main() {
     await client1.ping();
 
     expect(
-        client3.nameOwnerChanged,
-        emits(DBusNameOwnerChangedEvent('com.example.Test',
-            oldOwner: null, newOwner: client1.uniqueName)));
+      client3.nameOwnerChanged,
+      emits(
+        DBusNameOwnerChangedEvent(
+          'com.example.Test',
+          oldOwner: null,
+          newOwner: client1.uniqueName,
+        ),
+      ),
+    );
     await client3.ping();
 
     // Own a name with one client.
@@ -1672,8 +2095,9 @@ void main() {
 
   test('request name - queue, client closed', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     var client3 = DBusClient(address);
@@ -1690,13 +2114,20 @@ void main() {
 
     // Check name is transferred when the first client quits.
     expect(
-        client3.nameOwnerChanged,
-        emitsInOrder([
-          DBusNameOwnerChangedEvent('com.example.Test',
-              oldOwner: null, newOwner: client1.uniqueName),
-          DBusNameOwnerChangedEvent('com.example.Test',
-              oldOwner: client1.uniqueName, newOwner: client2.uniqueName)
-        ]));
+      client3.nameOwnerChanged,
+      emitsInOrder([
+        DBusNameOwnerChangedEvent(
+          'com.example.Test',
+          oldOwner: null,
+          newOwner: client1.uniqueName,
+        ),
+        DBusNameOwnerChangedEvent(
+          'com.example.Test',
+          oldOwner: client1.uniqueName,
+          newOwner: client2.uniqueName,
+        ),
+      ]),
+    );
     await client3.ping();
 
     // Own a name with one client.
@@ -1713,8 +2144,9 @@ void main() {
 
   test('request name - do not queue', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     var client3 = DBusClient(address);
@@ -1729,9 +2161,15 @@ void main() {
     await client1.ping();
 
     expect(
-        client3.nameOwnerChanged,
-        emits(DBusNameOwnerChangedEvent('com.example.Test',
-            oldOwner: null, newOwner: client1.uniqueName)));
+      client3.nameOwnerChanged,
+      emits(
+        DBusNameOwnerChangedEvent(
+          'com.example.Test',
+          oldOwner: null,
+          newOwner: client1.uniqueName,
+        ),
+      ),
+    );
     await client3.ping();
 
     // Own a name with one client.
@@ -1739,8 +2177,10 @@ void main() {
     expect(reply, equals(DBusRequestNameReply.primaryOwner));
 
     // Attempt to replace the name with another client.
-    reply = await client2.requestName('com.example.Test',
-        flags: {DBusRequestNameFlag.doNotQueue});
+    reply = await client2.requestName(
+      'com.example.Test',
+      flags: {DBusRequestNameFlag.doNotQueue},
+    );
     expect(reply, equals(DBusRequestNameReply.exists));
 
     // Check name is correctly owned and second client is not in queue.
@@ -1754,8 +2194,9 @@ void main() {
 
   test('request name - replace', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     var client3 = DBusClient(address);
@@ -1772,23 +2213,34 @@ void main() {
 
     // Check name is transferred to the second client.
     expect(
-        client3.nameOwnerChanged,
-        emitsInOrder([
-          DBusNameOwnerChangedEvent('com.example.Test',
-              oldOwner: null, newOwner: client1.uniqueName),
-          DBusNameOwnerChangedEvent('com.example.Test',
-              oldOwner: client1.uniqueName, newOwner: client2.uniqueName)
-        ]));
+      client3.nameOwnerChanged,
+      emitsInOrder([
+        DBusNameOwnerChangedEvent(
+          'com.example.Test',
+          oldOwner: null,
+          newOwner: client1.uniqueName,
+        ),
+        DBusNameOwnerChangedEvent(
+          'com.example.Test',
+          oldOwner: client1.uniqueName,
+          newOwner: client2.uniqueName,
+        ),
+      ]),
+    );
     await client3.ping();
 
     // Own a name with one client.
-    var reply = await client1.requestName('com.example.Test',
-        flags: {DBusRequestNameFlag.allowReplacement});
+    var reply = await client1.requestName(
+      'com.example.Test',
+      flags: {DBusRequestNameFlag.allowReplacement},
+    );
     expect(reply, equals(DBusRequestNameReply.primaryOwner));
 
     // Replace the name with another client.
-    reply = await client2.requestName('com.example.Test',
-        flags: {DBusRequestNameFlag.replaceExisting});
+    reply = await client2.requestName(
+      'com.example.Test',
+      flags: {DBusRequestNameFlag.replaceExisting},
+    );
     expect(reply, equals(DBusRequestNameReply.primaryOwner));
 
     // Check name is correctly owned and second client is in queue.
@@ -1802,8 +2254,9 @@ void main() {
 
   test('request name - replace, do not queue', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     var client3 = DBusClient(address);
@@ -1820,25 +2273,37 @@ void main() {
 
     // Check name is transferred to the second client.
     expect(
-        client3.nameOwnerChanged,
-        emitsInOrder([
-          DBusNameOwnerChangedEvent('com.example.Test',
-              oldOwner: null, newOwner: client1.uniqueName),
-          DBusNameOwnerChangedEvent('com.example.Test',
-              oldOwner: client1.uniqueName, newOwner: client2.uniqueName)
-        ]));
+      client3.nameOwnerChanged,
+      emitsInOrder([
+        DBusNameOwnerChangedEvent(
+          'com.example.Test',
+          oldOwner: null,
+          newOwner: client1.uniqueName,
+        ),
+        DBusNameOwnerChangedEvent(
+          'com.example.Test',
+          oldOwner: client1.uniqueName,
+          newOwner: client2.uniqueName,
+        ),
+      ]),
+    );
     await client3.ping();
 
     // Own a name with one client.
-    var reply = await client1.requestName('com.example.Test', flags: {
-      DBusRequestNameFlag.allowReplacement,
-      DBusRequestNameFlag.doNotQueue
-    });
+    var reply = await client1.requestName(
+      'com.example.Test',
+      flags: {
+        DBusRequestNameFlag.allowReplacement,
+        DBusRequestNameFlag.doNotQueue,
+      },
+    );
     expect(reply, equals(DBusRequestNameReply.primaryOwner));
 
     // Replace the name with another client.
-    reply = await client2.requestName('com.example.Test',
-        flags: {DBusRequestNameFlag.replaceExisting});
+    reply = await client2.requestName(
+      'com.example.Test',
+      flags: {DBusRequestNameFlag.replaceExisting},
+    );
     expect(reply, equals(DBusRequestNameReply.primaryOwner));
 
     // Check name is correctly owned and first client is not in queue.
@@ -1852,8 +2317,9 @@ void main() {
 
   test('request name - replace not allowed', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     var client3 = DBusClient(address);
@@ -1868,9 +2334,15 @@ void main() {
     await client1.ping();
 
     expect(
-        client3.nameOwnerChanged,
-        emits(DBusNameOwnerChangedEvent('com.example.Test',
-            oldOwner: null, newOwner: client1.uniqueName)));
+      client3.nameOwnerChanged,
+      emits(
+        DBusNameOwnerChangedEvent(
+          'com.example.Test',
+          oldOwner: null,
+          newOwner: client1.uniqueName,
+        ),
+      ),
+    );
     await client3.ping();
 
     // Own a name with one client.
@@ -1878,8 +2350,10 @@ void main() {
     expect(reply, equals(DBusRequestNameReply.primaryOwner));
 
     // Attempt to replace the name with another client.
-    reply = await client2.requestName('com.example.Test',
-        flags: {DBusRequestNameFlag.replaceExisting});
+    reply = await client2.requestName(
+      'com.example.Test',
+      flags: {DBusRequestNameFlag.replaceExisting},
+    );
     expect(reply, equals(DBusRequestNameReply.inQueue));
 
     // Check name is correctly owned and second client is in queue.
@@ -1893,8 +2367,9 @@ void main() {
 
   test('request name - invalid args', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -1903,26 +2378,31 @@ void main() {
 
     // Make requests with invalid args.
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'RequestName'),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'RequestName',
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'RequestName',
-            values: [DBusUint32(42)]),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'RequestName',
+        values: [DBusUint32(42)],
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
   });
 
   test('request name - unique', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -1930,14 +2410,17 @@ void main() {
     });
 
     // Attempt to request a unique bus name
-    expect(() => client.requestName(':1.42'),
-        throwsA(isA<DBusInvalidArgsException>()));
+    expect(
+      () => client.requestName(':1.42'),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
   });
 
   test('request name - not enough elements', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -1945,14 +2428,17 @@ void main() {
     });
 
     // Attempt to request a unique bus name
-    expect(() => client.requestName('foo'),
-        throwsA(isA<DBusInvalidArgsException>()));
+    expect(
+      () => client.requestName('foo'),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
   });
 
   test('request name - leading period', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -1960,14 +2446,17 @@ void main() {
     });
 
     // Attempt to request a unique bus name
-    expect(() => client.requestName('.foo.bar'),
-        throwsA(isA<DBusInvalidArgsException>()));
+    expect(
+      () => client.requestName('.foo.bar'),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
   });
 
   test('request name - trailing period', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -1975,14 +2464,17 @@ void main() {
     });
 
     // Attempt to request a unique bus name
-    expect(() => client.requestName('foo.bar.'),
-        throwsA(isA<DBusInvalidArgsException>()));
+    expect(
+      () => client.requestName('foo.bar.'),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
   });
 
   test('request name - empty element', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -1990,14 +2482,17 @@ void main() {
     });
 
     // Attempt to request a unique bus name
-    expect(() => client.requestName('foo..bar'),
-        throwsA(isA<DBusInvalidArgsException>()));
+    expect(
+      () => client.requestName('foo..bar'),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
   });
 
   test('release name', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -2011,13 +2506,20 @@ void main() {
     expect(client.nameAcquired, emits('com.example.Test'));
     expect(client.nameLost, emits('com.example.Test'));
     expect(
-        client.nameOwnerChanged,
-        emitsInOrder([
-          DBusNameOwnerChangedEvent('com.example.Test',
-              oldOwner: null, newOwner: client.uniqueName),
-          DBusNameOwnerChangedEvent('com.example.Test',
-              oldOwner: client.uniqueName, newOwner: null)
-        ]));
+      client.nameOwnerChanged,
+      emitsInOrder([
+        DBusNameOwnerChangedEvent(
+          'com.example.Test',
+          oldOwner: null,
+          newOwner: client.uniqueName,
+        ),
+        DBusNameOwnerChangedEvent(
+          'com.example.Test',
+          oldOwner: client.uniqueName,
+          newOwner: null,
+        ),
+      ]),
+    );
 
     // Request the name.
     var requestReply = await client.requestName('com.example.Test');
@@ -2036,8 +2538,9 @@ void main() {
 
   test('release name - non existant', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -2051,8 +2554,9 @@ void main() {
 
   test('release name - not owner', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -2062,8 +2566,10 @@ void main() {
     });
 
     // Own a name with one client.
-    var requestReply = await client1.requestName('com.example.Test',
-        flags: {DBusRequestNameFlag.allowReplacement});
+    var requestReply = await client1.requestName(
+      'com.example.Test',
+      flags: {DBusRequestNameFlag.allowReplacement},
+    );
     expect(requestReply, equals(DBusRequestNameReply.primaryOwner));
 
     // Attempt to release that name from another client.
@@ -2073,8 +2579,9 @@ void main() {
 
   test('release name - queue', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -2088,8 +2595,10 @@ void main() {
     expect(requestReply, equals(DBusRequestNameReply.primaryOwner));
 
     // Join queue for this name.
-    requestReply = await client2.requestName('com.example.Test',
-        flags: {DBusRequestNameFlag.replaceExisting});
+    requestReply = await client2.requestName(
+      'com.example.Test',
+      flags: {DBusRequestNameFlag.replaceExisting},
+    );
     expect(requestReply, equals(DBusRequestNameReply.inQueue));
 
     // Have the first client release the name.
@@ -2107,8 +2616,9 @@ void main() {
 
   test('release name - invalid args', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -2117,26 +2627,31 @@ void main() {
 
     // Make requests with invalid bus names.
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'ReleaseName'),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'ReleaseName',
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'ReleaseName',
-            values: [DBusUint32(42)]),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'ReleaseName',
+        values: [DBusUint32(42)],
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
   });
 
   test('release name - unique name', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -2144,14 +2659,17 @@ void main() {
     });
 
     // Attempt to release the unique name of this client.
-    expect(() => client.releaseName(client.uniqueName),
-        throwsA(isA<DBusInvalidArgsException>()));
+    expect(
+      () => client.releaseName(client.uniqueName),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
   });
 
   test('release name - empty', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -2160,13 +2678,16 @@ void main() {
 
     // Attempt to release an empty name.
     expect(
-        () => client.releaseName(''), throwsA(isA<DBusInvalidArgsException>()));
+      () => client.releaseName(''),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
   });
 
   test('release name - invalid name', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -2174,14 +2695,17 @@ void main() {
     });
 
     // Attempt to release an invalid name.
-    expect(() => client.releaseName('com.example.Test~1'),
-        throwsA(isA<DBusInvalidArgsException>()));
+    expect(
+      () => client.releaseName('com.example.Test~1'),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
   });
 
   test('list activatable names', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -2195,8 +2719,9 @@ void main() {
 
   test('names - invalid args', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -2205,87 +2730,113 @@ void main() {
 
     // Make requests with invalid args.
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'ListQueuedOwners'),
-        throwsA(isA<DBusInvalidArgsException>()));
-    expect(() => client.listQueuedOwners(''),
-        throwsA(isA<DBusInvalidArgsException>()));
-    expect(() => client.listQueuedOwners('com.example.Test~1'),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'ListQueuedOwners',
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
     expect(
-        () => client.callMethod(
-                destination: 'org.freedesktop.DBus',
-                path: DBusObjectPath('/'),
-                interface: 'org.freedesktop.DBus',
-                name: 'ListQueuedOwners',
-                values: [
-                  DBusString('org.freedesktop.DBus'),
-                  DBusString('More data')
-                ]),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.listQueuedOwners(''),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'ListNames',
-            values: [DBusString('Wrong data')]),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.listQueuedOwners('com.example.Test~1'),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'ListActivatableNames',
-            values: [DBusString('Wrong data')]),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'ListQueuedOwners',
+        values: [DBusString('org.freedesktop.DBus'), DBusString('More data')],
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'NameHasOwner'),
-        throwsA(isA<DBusInvalidArgsException>()));
-    expect(() => client.nameHasOwner(''),
-        throwsA(isA<DBusInvalidArgsException>()));
-    expect(() => client.nameHasOwner('com.example.Test~1'),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'ListNames',
+        values: [DBusString('Wrong data')],
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'NameHasOwner',
-            values: [DBusString('com.example.Test'), DBusString('Bad data')]),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'ListActivatableNames',
+        values: [DBusString('Wrong data')],
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'GetNameOwner'),
-        throwsA(isA<DBusInvalidArgsException>()));
-    expect(() => client.getNameOwner(''),
-        throwsA(isA<DBusInvalidArgsException>()));
-    expect(() => client.getNameOwner('com.example.Test~1'),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'NameHasOwner',
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'GetNameOwner',
-            values: [DBusString('com.example.Test'), DBusString('Bad data')]),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.nameHasOwner(''),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
+    expect(
+      () => client.nameHasOwner('com.example.Test~1'),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
+    expect(
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'NameHasOwner',
+        values: [DBusString('com.example.Test'), DBusString('Bad data')],
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
+    expect(
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'GetNameOwner',
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
+    expect(
+      () => client.getNameOwner(''),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
+    expect(
+      () => client.getNameOwner('com.example.Test~1'),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
+    expect(
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'GetNameOwner',
+        values: [DBusString('com.example.Test'), DBusString('Bad data')],
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
   });
 
   test('start service by name', () async {
     var server = ServerWithActivatableService();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -2294,12 +2845,13 @@ void main() {
 
     var names = await client.listActivatableNames();
     expect(
-        names,
-        equals([
-          'org.freedesktop.DBus',
-          'com.example.NotRunning',
-          'com.example.AlreadyRunning'
-        ]));
+      names,
+      equals([
+        'org.freedesktop.DBus',
+        'com.example.NotRunning',
+        'com.example.AlreadyRunning',
+      ]),
+    );
 
     var result1 = await client.startServiceByName('com.example.NotRunning');
     expect(result1, equals(DBusStartServiceByNameReply.success));
@@ -2307,34 +2859,45 @@ void main() {
     var result2 = await client.startServiceByName('com.example.AlreadyRunning');
     expect(result2, equals(DBusStartServiceByNameReply.alreadyRunning));
 
-    expect(() => client.startServiceByName('com.example.DoesNotExist'),
-        throwsA(isA<DBusServiceUnknownException>()));
+    expect(
+      () => client.startServiceByName('com.example.DoesNotExist'),
+      throwsA(isA<DBusServiceUnknownException>()),
+    );
 
-    expect(() => client.startServiceByName(''),
-        throwsA(isA<DBusInvalidArgsException>()));
-    expect(() => client.startServiceByName('com.example.Test~1'),
-        throwsA(isA<DBusInvalidArgsException>()));
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'StartServiceByName'),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.startServiceByName(''),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'StartServiceByName',
-            values: [DBusUint32(42)]),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.startServiceByName('com.example.Test~1'),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
+    expect(
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'StartServiceByName',
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
+    expect(
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'StartServiceByName',
+        values: [DBusUint32(42)],
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
   });
 
   test('get unix user - server', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -2347,8 +2910,9 @@ void main() {
 
   test('get unix user - client', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -2360,59 +2924,74 @@ void main() {
     // Connect client.
     await client1.ping();
 
-    expect(() => client2.getConnectionUnixUser(client1.uniqueName),
-        throwsA(isA<DBusNotSupportedException>()));
+    expect(
+      () => client2.getConnectionUnixUser(client1.uniqueName),
+      throwsA(isA<DBusNotSupportedException>()),
+    );
   });
 
   test('get unix user - unknown client', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
       await server.close();
     });
 
-    expect(() => client.getConnectionUnixUser('com.example.NotAClient'),
-        throwsA(isA<DBusErrorException>()));
+    expect(
+      () => client.getConnectionUnixUser('com.example.NotAClient'),
+      throwsA(isA<DBusErrorException>()),
+    );
   });
 
   test('get unix user - invalid args', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
       await server.close();
     });
 
-    expect(() => client.getConnectionUnixUser(''),
-        throwsA(isA<DBusInvalidArgsException>()));
-    expect(() => client.getConnectionUnixUser('com.example.Test~1'),
-        throwsA(isA<DBusInvalidArgsException>()));
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'GetConnectionUnixUser'),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.getConnectionUnixUser(''),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'GetConnectionUnixUser',
-            values: [DBusUint32(42)]),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.getConnectionUnixUser('com.example.Test~1'),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
+    expect(
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'GetConnectionUnixUser',
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
+    expect(
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'GetConnectionUnixUser',
+        values: [DBusUint32(42)],
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
   });
 
   test('get process id - server', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -2425,8 +3004,9 @@ void main() {
 
   test('get process id - client', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -2438,75 +3018,92 @@ void main() {
     // Connect client.
     await client1.ping();
 
-    expect(() => client2.getConnectionUnixProcessId(client1.uniqueName),
-        throwsA(isA<DBusNotSupportedException>()));
+    expect(
+      () => client2.getConnectionUnixProcessId(client1.uniqueName),
+      throwsA(isA<DBusNotSupportedException>()),
+    );
   });
 
   test('get process id - unknown client', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
       await server.close();
     });
 
-    expect(() => client.getConnectionUnixProcessId('com.example.NotAClient'),
-        throwsA(isA<DBusErrorException>()));
+    expect(
+      () => client.getConnectionUnixProcessId('com.example.NotAClient'),
+      throwsA(isA<DBusErrorException>()),
+    );
   });
 
   test('get process id - invalid args', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
       await server.close();
     });
 
-    expect(() => client.getConnectionUnixProcessId(''),
-        throwsA(isA<DBusInvalidArgsException>()));
-    expect(() => client.getConnectionUnixProcessId('com.example.Test~1'),
-        throwsA(isA<DBusInvalidArgsException>()));
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'GetConnectionUnixProcessID'),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.getConnectionUnixProcessId(''),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'GetConnectionUnixProcessID',
-            values: [DBusUint32(42)]),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.getConnectionUnixProcessId('com.example.Test~1'),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
+    expect(
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'GetConnectionUnixProcessID',
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
+    expect(
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'GetConnectionUnixProcessID',
+        values: [DBusUint32(42)],
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
   });
 
   test('get credentials - server', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
       await server.close();
     });
 
-    var credentials =
-        await client.getConnectionCredentials('org.freedesktop.DBus');
+    var credentials = await client.getConnectionCredentials(
+      'org.freedesktop.DBus',
+    );
     expect(credentials.unixUserId, equals(getuid()));
     expect(credentials.processId, equals(pid));
   });
 
   test('get credentials - client', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -2518,59 +3115,74 @@ void main() {
     // Connect client.
     await client1.ping();
 
-    expect(() => client2.getConnectionCredentials(client1.uniqueName),
-        throwsA(isA<DBusNotSupportedException>()));
+    expect(
+      () => client2.getConnectionCredentials(client1.uniqueName),
+      throwsA(isA<DBusNotSupportedException>()),
+    );
   });
 
   test('get credentials - unknown client', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
       await server.close();
     });
 
-    expect(() => client.getConnectionCredentials('com.example.NotAClient'),
-        throwsA(isA<DBusErrorException>()));
+    expect(
+      () => client.getConnectionCredentials('com.example.NotAClient'),
+      throwsA(isA<DBusErrorException>()),
+    );
   });
 
   test('get credentials - invalid args', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
       await server.close();
     });
 
-    expect(() => client.getConnectionCredentials(''),
-        throwsA(isA<DBusInvalidArgsException>()));
-    expect(() => client.getConnectionCredentials('com.example.Test~1'),
-        throwsA(isA<DBusInvalidArgsException>()));
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'GetConnectionCredentials'),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.getConnectionCredentials(''),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'GetConnectionCredentials',
-            values: [DBusUint32(42)]),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.getConnectionCredentials('com.example.Test~1'),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
+    expect(
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'GetConnectionCredentials',
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
+    expect(
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'GetConnectionCredentials',
+        values: [DBusUint32(42)],
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
   });
 
   test('get id', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -2583,8 +3195,9 @@ void main() {
 
   test('get machine id - server', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -2599,8 +3212,9 @@ void main() {
 
   test('get machine id - client', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -2620,8 +3234,9 @@ void main() {
 
   test('register object twice', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -2636,8 +3251,9 @@ void main() {
 
   test('register object second client', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -2654,8 +3270,9 @@ void main() {
 
   test('call method', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -2666,26 +3283,33 @@ void main() {
 
     // Create a client that exposes a method.
     await client1.registerObject(
-        TestObject(expectedMethodName: 'Test', expectedMethodValues: [
-      DBusString('Hello'),
-      DBusUint32(42)
-    ], methodResponses: {
-      'Test': DBusMethodSuccessResponse([DBusString('World'), DBusUint32(99)])
-    }));
+      TestObject(
+        expectedMethodName: 'Test',
+        expectedMethodValues: [DBusString('Hello'), DBusUint32(42)],
+        methodResponses: {
+          'Test': DBusMethodSuccessResponse([
+            DBusString('World'),
+            DBusUint32(99),
+          ]),
+        },
+      ),
+    );
 
     // Call the method from another client.
     var response = await client2.callMethod(
-        destination: client1.uniqueName,
-        path: DBusObjectPath('/'),
-        name: 'Test',
-        values: [DBusString('Hello'), DBusUint32(42)]);
+      destination: client1.uniqueName,
+      path: DBusObjectPath('/'),
+      name: 'Test',
+      values: [DBusString('Hello'), DBusUint32(42)],
+    );
     expect(response.values, equals([DBusString('World'), DBusUint32(99)]));
   });
 
   test('call method - all types', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -2720,49 +3344,59 @@ void main() {
       DBusArray.string(['Hello', 'World']),
       DBusArray.objectPath([
         DBusObjectPath('/com/example/Test1'),
-        DBusObjectPath('/com/example/Test2')
+        DBusObjectPath('/com/example/Test2'),
       ]),
       DBusArray(DBusSignature('g'), [DBusSignature('y'), DBusSignature('as')]),
       DBusArray.variant([DBusString('Hello'), DBusUint32(42)]),
       DBusArray(DBusSignature('(sy)'), [
         DBusStruct([DBusString('A'), DBusByte(65)]),
-        DBusStruct([DBusString('B'), DBusByte(66)])
+        DBusStruct([DBusString('B'), DBusByte(66)]),
       ]),
       DBusArray(DBusSignature('as'), [
         DBusArray.string(['H', 'e', 'l', 'l', 'o']),
-        DBusArray.string(['W', 'o', 'r', 'l', 'd'])
+        DBusArray.string(['W', 'o', 'r', 'l', 'd']),
       ]),
       DBusArray(DBusSignature('a{sv}'), [
-        DBusDict.stringVariant(
-            {'one': DBusByte(1), 'two': DBusInt16(2), 'three': DBusUint32(3)}),
-        DBusDict.stringVariant(
-            {'A': DBusString('Aye'), 'B': DBusDouble(3.14159)})
+        DBusDict.stringVariant({
+          'one': DBusByte(1),
+          'two': DBusInt16(2),
+          'three': DBusUint32(3),
+        }),
+        DBusDict.stringVariant({
+          'A': DBusString('Aye'),
+          'B': DBusDouble(3.14159),
+        }),
       ]),
       DBusDict(DBusSignature('i'), DBusSignature('s'), {
         DBusInt32(1): DBusString('one'),
         DBusInt32(2): DBusString('two'),
-        DBusInt32(3): DBusString('three')
-      })
+        DBusInt32(3): DBusString('three'),
+      }),
     ];
 
     // Create a client that exposes a method that takes and returns all the DBus data types.
-    await client1.registerObject(TestObject(
+    await client1.registerObject(
+      TestObject(
         expectedMethodValues: allTypes,
-        methodResponses: {'Test': DBusMethodSuccessResponse(allTypes)}));
+        methodResponses: {'Test': DBusMethodSuccessResponse(allTypes)},
+      ),
+    );
 
     // Call the method from another client.
     var response = await client2.callMethod(
-        destination: client1.uniqueName,
-        path: DBusObjectPath('/'),
-        name: 'Test',
-        values: allTypes);
+      destination: client1.uniqueName,
+      path: DBusObjectPath('/'),
+      name: 'Test',
+      values: allTypes,
+    );
     expect(response.values, equals(allTypes));
   });
 
   test('call method - unix fd types', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -2773,29 +3407,35 @@ void main() {
 
     var unixFdTypes = [
       DBusUnixFd(ResourceHandle.fromStdin(stdin)),
-      DBusStruct(
-          [DBusUint32(0), DBusUnixFd(ResourceHandle.fromStdout(stdout))]),
+      DBusStruct([
+        DBusUint32(0),
+        DBusUnixFd(ResourceHandle.fromStdout(stdout)),
+      ]),
       DBusVariant(DBusUnixFd(ResourceHandle.fromStdout(stdout))),
       DBusArray(DBusSignature('h'), [
         DBusUnixFd(ResourceHandle.fromStdin(stdin)),
-        DBusUnixFd(ResourceHandle.fromStdout(stdout))
+        DBusUnixFd(ResourceHandle.fromStdout(stdout)),
       ]),
       DBusDict(DBusSignature('i'), DBusSignature('h'), {
         DBusInt32(0): DBusUnixFd(ResourceHandle.fromStdin(stdin)),
-        DBusInt32(1): DBusUnixFd(ResourceHandle.fromStdout(stdout))
-      })
+        DBusInt32(1): DBusUnixFd(ResourceHandle.fromStdout(stdout)),
+      }),
     ];
 
     // Create a client that exposes a method that takes and returns all the DBus unix fd data types.
-    await client1.registerObject(TestObject(
-        methodResponses: {'Test': DBusMethodSuccessResponse(unixFdTypes)}));
+    await client1.registerObject(
+      TestObject(
+        methodResponses: {'Test': DBusMethodSuccessResponse(unixFdTypes)},
+      ),
+    );
 
     // Call the method from another client.
     var response = await client2.callMethod(
-        destination: client1.uniqueName,
-        path: DBusObjectPath('/'),
-        name: 'Test',
-        values: unixFdTypes);
+      destination: client1.uniqueName,
+      path: DBusObjectPath('/'),
+      name: 'Test',
+      values: unixFdTypes,
+    );
     expect(response.values, hasLength(5));
     expect(response.values[0], isA<DBusUnixFd>());
     expect(response.values[1].asStruct().elementAt(1), isA<DBusUnixFd>());
@@ -2808,8 +3448,9 @@ void main() {
 
   test('call method - no response', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -2819,23 +3460,26 @@ void main() {
     });
 
     // Create a client that exposes a method.
-    await client1
-        .registerObject(TestObject(expectedMethodNoReplyExpected: true));
+    await client1.registerObject(
+      TestObject(expectedMethodNoReplyExpected: true),
+    );
 
     // Call the method from another client.
     var response = await client2.callMethod(
-        destination: client1.uniqueName,
-        path: DBusObjectPath('/'),
-        name: 'Test',
-        values: [DBusString('Hello'), DBusUint32(42)],
-        noReplyExpected: true);
+      destination: client1.uniqueName,
+      path: DBusObjectPath('/'),
+      name: 'Test',
+      values: [DBusString('Hello'), DBusUint32(42)],
+      noReplyExpected: true,
+    );
     expect(response.values, equals([]));
   });
 
   test('call method - registered name', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -2847,21 +3491,24 @@ void main() {
     // Create a client that exposes a method.
     await client1.requestName('com.example.Test');
     await client1.registerObject(
-        TestObject(methodResponses: {'Test': DBusMethodSuccessResponse()}));
+      TestObject(methodResponses: {'Test': DBusMethodSuccessResponse()}),
+    );
 
     // Call the method from another client.
     var response = await client2.callMethod(
-        destination: 'com.example.Test',
-        path: DBusObjectPath('/'),
-        name: 'Test',
-        values: [DBusString('Hello'), DBusUint32(42)]);
+      destination: 'com.example.Test',
+      path: DBusObjectPath('/'),
+      name: 'Test',
+      values: [DBusString('Hello'), DBusUint32(42)],
+    );
     expect(response.values, equals([]));
   });
 
   test('call method - dict container key', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -2876,21 +3523,25 @@ void main() {
     // Call the method from another client.
     try {
       await client2.callMethod(
-          destination: client1.uniqueName,
-          path: DBusObjectPath('/'),
-          name: 'Test',
-          values: [DBusDict(DBusSignature('(is)'), DBusSignature('s'), {})]);
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        name: 'Test',
+        values: [DBusDict(DBusSignature('(is)'), DBusSignature('s'), {})],
+      );
       fail('Expected UnsupportedError');
     } on UnsupportedError catch (e) {
-      expect(e.message,
-          equals("D-Bus doesn't support dicts with non basic key types"));
+      expect(
+        e.message,
+        equals("D-Bus doesn't support dicts with non basic key types"),
+      );
     }
   });
 
   test('call method - maybe type', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -2905,10 +3556,11 @@ void main() {
     // Call the method from another client.
     try {
       await client2.callMethod(
-          destination: client1.uniqueName,
-          path: DBusObjectPath('/'),
-          name: 'Test',
-          values: [DBusMaybe(DBusSignature('s'), DBusString('Hello'))]);
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        name: 'Test',
+        values: [DBusMaybe(DBusSignature('s'), DBusString('Hello'))],
+      );
       fail('Expected UnsupportedError');
     } on UnsupportedError catch (e) {
       expect(e.message, equals("D-Bus doesn't support reserved maybe type"));
@@ -2917,8 +3569,9 @@ void main() {
 
   test('call method - maybe signature', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -2933,131 +3586,25 @@ void main() {
     // Call the method from another client.
     try {
       await client2.callMethod(
-          destination: client1.uniqueName,
-          path: DBusObjectPath('/'),
-          name: 'Test',
-          values: [DBusSignature('ms')]);
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        name: 'Test',
+        values: [DBusSignature('ms')],
+      );
       fail('Expected UnsupportedError');
     } on UnsupportedError catch (e) {
-      expect(e.message,
-          equals("D-Bus doesn't support reserved maybe type in signatures"));
+      expect(
+        e.message,
+        equals("D-Bus doesn't support reserved maybe type in signatures"),
+      );
     }
   });
 
   test('call method - expected signature', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
-    var client1 = DBusClient(address);
-    var client2 = DBusClient(address);
-    addTearDown(() async {
-      await client1.close();
-      await client2.close();
-      await server.close();
-    });
-
-    // Create a client that exposes a method.
-    await client1.registerObject(TestObject(methodResponses: {
-      'Test': DBusMethodSuccessResponse([DBusString('Hello'), DBusUint32(42)])
-    }));
-
-    // Call the method from another client and check the signature.
-    var response = await client2.callMethod(
-        destination: client1.uniqueName,
-        path: DBusObjectPath('/'),
-        name: 'Test',
-        replySignature: DBusSignature('su'));
-    expect(response.values, equals([DBusString('Hello'), DBusUint32(42)]));
-  });
-
-  test('call method - expected signature mismatch', () async {
-    var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
-    var client1 = DBusClient(address);
-    var client2 = DBusClient(address);
-    addTearDown(() async {
-      await client1.close();
-      await client2.close();
-      await server.close();
-    });
-
-    // Create a client that exposes a method.
-    await client1.registerObject(TestObject(methodResponses: {
-      'Test': DBusMethodSuccessResponse([DBusString('Hello'), DBusUint32(42)])
-    }));
-
-    // Call the method from another client and check the signature.
-    try {
-      await client2.callMethod(
-          destination: client1.uniqueName,
-          path: DBusObjectPath('/'),
-          name: 'Test',
-          replySignature: DBusSignature('us'));
-      fail('Expected DBusReplySignatureException');
-    } on DBusReplySignatureException catch (e) {
-      expect(e.response.values, equals([DBusString('Hello'), DBusUint32(42)]));
-    }
-  });
-
-  test('call method - no autostart', () async {
-    var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
-    var client1 = DBusClient(address);
-    var client2 = DBusClient(address);
-    addTearDown(() async {
-      await client1.close();
-      await client2.close();
-      await server.close();
-    });
-
-    // Create a client that exposes a method.
-    await client1.registerObject(TestObject(
-        expectedMethodNoAutoStart: true,
-        methodResponses: {'Test': DBusMethodSuccessResponse()}));
-
-    // Call the method from another client.
-    var response = await client2.callMethod(
-        destination: client1.uniqueName,
-        path: DBusObjectPath('/'),
-        name: 'Test',
-        values: [DBusString('Hello'), DBusUint32(42)],
-        noAutoStart: true);
-    expect(response.values, equals([]));
-  });
-
-  test('call method - allow interactive authorization', () async {
-    var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
-    var client1 = DBusClient(address);
-    var client2 = DBusClient(address);
-    addTearDown(() async {
-      await client1.close();
-      await client2.close();
-      await server.close();
-    });
-
-    // Create a client that exposes a method.
-    await client1.registerObject(TestObject(
-        expectedMethodAllowInteractiveAuthorization: true,
-        methodResponses: {'Test': DBusMethodSuccessResponse()}));
-
-    // Call the method from another client.
-    var response = await client2.callMethod(
-        destination: client1.uniqueName,
-        path: DBusObjectPath('/'),
-        name: 'Test',
-        values: [DBusString('Hello'), DBusUint32(42)],
-        allowInteractiveAuthorization: true);
-    expect(response.values, equals([]));
-  });
-
-  test('call method - error', () async {
-    var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3068,28 +3615,31 @@ void main() {
 
     // Create a client that exposes a method.
     await client1.registerObject(
-        TestObject(expectedMethodName: 'Test', methodResponses: {
-      'Test': DBusMethodErrorResponse(
-          'com.example.Error', [DBusString('Count'), DBusUint32(42)])
-    }));
+      TestObject(
+        methodResponses: {
+          'Test': DBusMethodSuccessResponse([
+            DBusString('Hello'),
+            DBusUint32(42),
+          ]),
+        },
+      ),
+    );
 
-    // Call the method from another client.
-    try {
-      await client2.callMethod(
-          destination: client1.uniqueName,
-          path: DBusObjectPath('/'),
-          name: 'Test');
-      fail('Expected DBusMethodResponseException');
-    } on DBusMethodResponseException catch (e) {
-      expect(e.response.errorName, equals('com.example.Error'));
-      expect(e.response.values, equals([DBusString('Count'), DBusUint32(42)]));
-    }
+    // Call the method from another client and check the signature.
+    var response = await client2.callMethod(
+      destination: client1.uniqueName,
+      path: DBusObjectPath('/'),
+      name: 'Test',
+      replySignature: DBusSignature('su'),
+    );
+    expect(response.values, equals([DBusString('Hello'), DBusUint32(42)]));
   });
 
-  test('call method - failed', () async {
+  test('call method - expected signature mismatch', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3099,16 +3649,164 @@ void main() {
     });
 
     // Create a client that exposes a method.
-    await client1.registerObject(TestObject(methodResponses: {
-      'Test': DBusMethodErrorResponse.failed('Failure message')
-    }));
+    await client1.registerObject(
+      TestObject(
+        methodResponses: {
+          'Test': DBusMethodSuccessResponse([
+            DBusString('Hello'),
+            DBusUint32(42),
+          ]),
+        },
+      ),
+    );
+
+    // Call the method from another client and check the signature.
+    try {
+      await client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        name: 'Test',
+        replySignature: DBusSignature('us'),
+      );
+      fail('Expected DBusReplySignatureException');
+    } on DBusReplySignatureException catch (e) {
+      expect(e.response.values, equals([DBusString('Hello'), DBusUint32(42)]));
+    }
+  });
+
+  test('call method - no autostart', () async {
+    var server = DBusServer();
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
+    var client1 = DBusClient(address);
+    var client2 = DBusClient(address);
+    addTearDown(() async {
+      await client1.close();
+      await client2.close();
+      await server.close();
+    });
+
+    // Create a client that exposes a method.
+    await client1.registerObject(
+      TestObject(
+        expectedMethodNoAutoStart: true,
+        methodResponses: {'Test': DBusMethodSuccessResponse()},
+      ),
+    );
+
+    // Call the method from another client.
+    var response = await client2.callMethod(
+      destination: client1.uniqueName,
+      path: DBusObjectPath('/'),
+      name: 'Test',
+      values: [DBusString('Hello'), DBusUint32(42)],
+      noAutoStart: true,
+    );
+    expect(response.values, equals([]));
+  });
+
+  test('call method - allow interactive authorization', () async {
+    var server = DBusServer();
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
+    var client1 = DBusClient(address);
+    var client2 = DBusClient(address);
+    addTearDown(() async {
+      await client1.close();
+      await client2.close();
+      await server.close();
+    });
+
+    // Create a client that exposes a method.
+    await client1.registerObject(
+      TestObject(
+        expectedMethodAllowInteractiveAuthorization: true,
+        methodResponses: {'Test': DBusMethodSuccessResponse()},
+      ),
+    );
+
+    // Call the method from another client.
+    var response = await client2.callMethod(
+      destination: client1.uniqueName,
+      path: DBusObjectPath('/'),
+      name: 'Test',
+      values: [DBusString('Hello'), DBusUint32(42)],
+      allowInteractiveAuthorization: true,
+    );
+    expect(response.values, equals([]));
+  });
+
+  test('call method - error', () async {
+    var server = DBusServer();
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
+    var client1 = DBusClient(address);
+    var client2 = DBusClient(address);
+    addTearDown(() async {
+      await client1.close();
+      await client2.close();
+      await server.close();
+    });
+
+    // Create a client that exposes a method.
+    await client1.registerObject(
+      TestObject(
+        expectedMethodName: 'Test',
+        methodResponses: {
+          'Test': DBusMethodErrorResponse('com.example.Error', [
+            DBusString('Count'),
+            DBusUint32(42),
+          ]),
+        },
+      ),
+    );
 
     // Call the method from another client.
     try {
       await client2.callMethod(
-          destination: client1.uniqueName,
-          path: DBusObjectPath('/'),
-          name: 'Test');
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        name: 'Test',
+      );
+      fail('Expected DBusMethodResponseException');
+    } on DBusMethodResponseException catch (e) {
+      expect(e.response.errorName, equals('com.example.Error'));
+      expect(e.response.values, equals([DBusString('Count'), DBusUint32(42)]));
+    }
+  });
+
+  test('call method - failed', () async {
+    var server = DBusServer();
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
+    var client1 = DBusClient(address);
+    var client2 = DBusClient(address);
+    addTearDown(() async {
+      await client1.close();
+      await client2.close();
+      await server.close();
+    });
+
+    // Create a client that exposes a method.
+    await client1.registerObject(
+      TestObject(
+        methodResponses: {
+          'Test': DBusMethodErrorResponse.failed('Failure message'),
+        },
+      ),
+    );
+
+    // Call the method from another client.
+    try {
+      await client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        name: 'Test',
+      );
       fail('Expected DBusMethodResponseException');
     } on DBusFailedException catch (e) {
       expect(e.message, equals('Failure message'));
@@ -3117,8 +3815,9 @@ void main() {
 
   test('call method - empty object', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3132,18 +3831,21 @@ void main() {
 
     // Call the method from another client.
     expect(
-        () => client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            name: 'Test',
-            values: [DBusString('Hello'), DBusUint32(42)]),
-        throwsA(isA<DBusUnknownInterfaceException>()));
+      () => client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        name: 'Test',
+        values: [DBusString('Hello'), DBusUint32(42)],
+      ),
+      throwsA(isA<DBusUnknownInterfaceException>()),
+    );
   });
 
   test('call method - unknown object', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3157,17 +3859,20 @@ void main() {
 
     // Try and access an unknown object.
     expect(
-        () => client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/no/such/object'),
-            name: 'Test'),
-        throwsA(isA<DBusUnknownObjectException>()));
+      () => client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/no/such/object'),
+        name: 'Test',
+      ),
+      throwsA(isA<DBusUnknownObjectException>()),
+    );
   });
 
   test('call method - unknown interface', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3181,18 +3886,21 @@ void main() {
 
     // Try and access an unknown interface on that object.
     expect(
-        () => client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            interface: 'com.example.NoSuchInterface',
-            name: 'Test'),
-        throwsA(isA<DBusUnknownInterfaceException>()));
+      () => client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        interface: 'com.example.NoSuchInterface',
+        name: 'Test',
+      ),
+      throwsA(isA<DBusUnknownInterfaceException>()),
+    );
   });
 
   test('call method - unknown method', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3206,17 +3914,20 @@ void main() {
 
     // Try and access an unknown method on that object.
     expect(
-        () => client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            name: 'NoSuchMethod'),
-        throwsA(isA<DBusUnknownMethodException>()));
+      () => client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        name: 'NoSuchMethod',
+      ),
+      throwsA(isA<DBusUnknownMethodException>()),
+    );
   });
 
   test('call method - not supported', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3226,23 +3937,30 @@ void main() {
     });
 
     // Create a client that exposes a method that generates an access denied error.
-    await client1.registerObject(TestObject(methodResponses: {
-      'Test': DBusMethodErrorResponse.notSupported('Failure message')
-    }));
+    await client1.registerObject(
+      TestObject(
+        methodResponses: {
+          'Test': DBusMethodErrorResponse.notSupported('Failure message'),
+        },
+      ),
+    );
 
     // Call the method from another client.
     expect(
-        () => client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            name: 'Test'),
-        throwsA(isA<DBusNotSupportedException>()));
+      () => client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        name: 'Test',
+      ),
+      throwsA(isA<DBusNotSupportedException>()),
+    );
   });
 
   test('call method - access denied', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3252,23 +3970,30 @@ void main() {
     });
 
     // Create a client that exposes a method that generates an access denied error.
-    await client1.registerObject(TestObject(methodResponses: {
-      'Test': DBusMethodErrorResponse.accessDenied('Failure message')
-    }));
+    await client1.registerObject(
+      TestObject(
+        methodResponses: {
+          'Test': DBusMethodErrorResponse.accessDenied('Failure message'),
+        },
+      ),
+    );
 
     // Call the method from another client.
     expect(
-        () => client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            name: 'Test'),
-        throwsA(isA<DBusAccessDeniedException>()));
+      () => client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        name: 'Test',
+      ),
+      throwsA(isA<DBusAccessDeniedException>()),
+    );
   });
 
   test('call method - auth failed', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3278,23 +4003,30 @@ void main() {
     });
 
     // Create a client that exposes a method that generates an auth failed error.
-    await client1.registerObject(TestObject(methodResponses: {
-      'Test': DBusMethodErrorResponse.authFailed('Failure message')
-    }));
+    await client1.registerObject(
+      TestObject(
+        methodResponses: {
+          'Test': DBusMethodErrorResponse.authFailed('Failure message'),
+        },
+      ),
+    );
 
     // Call the method from another client.
     expect(
-        () => client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            name: 'Test'),
-        throwsA(isA<DBusAuthFailedException>()));
+      () => client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        name: 'Test',
+      ),
+      throwsA(isA<DBusAuthFailedException>()),
+    );
   });
 
   test('call method - timeout', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3304,23 +4036,30 @@ void main() {
     });
 
     // Create a client that exposes a method that generates a timeout error.
-    await client1.registerObject(TestObject(methodResponses: {
-      'Test': DBusMethodErrorResponse.timeout('Failure message')
-    }));
+    await client1.registerObject(
+      TestObject(
+        methodResponses: {
+          'Test': DBusMethodErrorResponse.timeout('Failure message'),
+        },
+      ),
+    );
 
     // Call the method from another client.
     expect(
-        () => client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            name: 'Test'),
-        throwsA(isA<DBusTimeoutException>()));
+      () => client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        name: 'Test',
+      ),
+      throwsA(isA<DBusTimeoutException>()),
+    );
   });
 
   test('call method - timed out', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3330,23 +4069,30 @@ void main() {
     });
 
     // Create a client that exposes a method that generates a timeout error.
-    await client1.registerObject(TestObject(methodResponses: {
-      'Test': DBusMethodErrorResponse.timedOut('Failure message')
-    }));
+    await client1.registerObject(
+      TestObject(
+        methodResponses: {
+          'Test': DBusMethodErrorResponse.timedOut('Failure message'),
+        },
+      ),
+    );
 
     // Call the method from another client.
     expect(
-        () => client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            name: 'Test'),
-        throwsA(isA<DBusTimedOutException>()));
+      () => client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        name: 'Test',
+      ),
+      throwsA(isA<DBusTimedOutException>()),
+    );
   });
 
   test('call method - remote object', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3356,29 +4102,37 @@ void main() {
     });
 
     // Create a client that exposes a method.
-    await client1.registerObject(TestObject(
+    await client1.registerObject(
+      TestObject(
         expectedMethodName: 'com.example.Test.Foo',
-        expectedMethodValues: [
-          DBusString('Hello'),
-          DBusUint32(42)
-        ],
+        expectedMethodValues: [DBusString('Hello'), DBusUint32(42)],
         methodResponses: {
-          'com.example.Test.Foo':
-              DBusMethodSuccessResponse([DBusString('World'), DBusUint32(99)])
-        }));
+          'com.example.Test.Foo': DBusMethodSuccessResponse([
+            DBusString('World'),
+            DBusUint32(99),
+          ]),
+        },
+      ),
+    );
 
     // Call the method from another client.
-    var remoteObject = DBusRemoteObject(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
-    var response = await remoteObject.callMethod(
-        'com.example.Test', 'Foo', [DBusString('Hello'), DBusUint32(42)]);
+    var remoteObject = DBusRemoteObject(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
+    var response = await remoteObject.callMethod('com.example.Test', 'Foo', [
+      DBusString('Hello'),
+      DBusUint32(42),
+    ]);
     expect(response.values, equals([DBusString('World'), DBusUint32(99)]));
   });
 
   test('call method - remote object - expected signature', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3388,25 +4142,38 @@ void main() {
     });
 
     // Create a client that exposes a method.
-    await client1.registerObject(TestObject(
+    await client1.registerObject(
+      TestObject(
         expectedMethodName: 'com.example.Test.Foo',
         methodResponses: {
-          'com.example.Test.Foo':
-              DBusMethodSuccessResponse([DBusString('World'), DBusUint32(99)])
-        }));
+          'com.example.Test.Foo': DBusMethodSuccessResponse([
+            DBusString('World'),
+            DBusUint32(99),
+          ]),
+        },
+      ),
+    );
 
     // Call the method from another client.
-    var remoteObject = DBusRemoteObject(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
-    var response = await remoteObject.callMethod('com.example.Test', 'Foo', [],
-        replySignature: DBusSignature('su'));
+    var remoteObject = DBusRemoteObject(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
+    var response = await remoteObject.callMethod(
+      'com.example.Test',
+      'Foo',
+      [],
+      replySignature: DBusSignature('su'),
+    );
     expect(response.values, equals([DBusString('World'), DBusUint32(99)]));
   });
 
   test('call method - remote object - expected signature mismatch', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3416,19 +4183,31 @@ void main() {
     });
 
     // Create a client that exposes a method.
-    await client1.registerObject(TestObject(
+    await client1.registerObject(
+      TestObject(
         expectedMethodName: 'com.example.Test.Foo',
         methodResponses: {
-          'com.example.Test.Foo':
-              DBusMethodSuccessResponse([DBusString('Hello'), DBusUint32(42)])
-        }));
+          'com.example.Test.Foo': DBusMethodSuccessResponse([
+            DBusString('Hello'),
+            DBusUint32(42),
+          ]),
+        },
+      ),
+    );
 
     // Call the method from another client.
-    var remoteObject = DBusRemoteObject(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
+    var remoteObject = DBusRemoteObject(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
     try {
-      await remoteObject.callMethod('com.example.Test', 'Foo', [],
-          replySignature: DBusSignature('us'));
+      await remoteObject.callMethod(
+        'com.example.Test',
+        'Foo',
+        [],
+        replySignature: DBusSignature('us'),
+      );
       fail('Expected DBusReplySignatureException');
     } on DBusReplySignatureException catch (e) {
       expect(e.response.values, equals([DBusString('Hello'), DBusUint32(42)]));
@@ -3437,8 +4216,9 @@ void main() {
 
   test('call method - invalid name', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3452,59 +4232,72 @@ void main() {
 
     // Method name empty.
     expect(
-        client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            name: '',
-            values: []),
-        throwsFormatException);
+      client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        name: '',
+        values: [],
+      ),
+      throwsFormatException,
+    );
 
     // Method name too long.
     expect(
-        client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            name: 'x' * 256,
-            values: []),
-        throwsFormatException);
+      client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        name: 'x' * 256,
+        values: [],
+      ),
+      throwsFormatException,
+    );
 
     // Method name contains invalid characters.
     expect(
-        client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            name: 'Test!',
-            values: []),
-        throwsFormatException);
+      client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        name: 'Test!',
+        values: [],
+      ),
+      throwsFormatException,
+    );
     expect(
-        client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            name: 'Test-Method',
-            values: []),
-        throwsFormatException);
+      client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        name: 'Test-Method',
+        values: [],
+      ),
+      throwsFormatException,
+    );
     expect(
-        client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            name: '🤪',
-            values: []),
-        throwsFormatException);
+      client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        name: '🤪',
+        values: [],
+      ),
+      throwsFormatException,
+    );
 
     // Must not begin with a digit.
     expect(
-        client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            name: '0Test',
-            values: []),
-        throwsFormatException);
+      client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        name: '0Test',
+        values: [],
+      ),
+      throwsFormatException,
+    );
   });
 
   test('subscribe signal', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3518,28 +4311,36 @@ void main() {
     await client1.registerObject(object);
 
     // Subscribe to the signal from another client.
-    var signals =
-        DBusSignalStream(client2, interface: 'com.example.Test', name: 'Ping');
-    signals.listen(expectAsync1((signal) {
-      expect(signal.sender, equals(client1.uniqueName));
-      expect(signal.path, equals(DBusObjectPath('/')));
-      expect(signal.interface, equals('com.example.Test'));
-      expect(signal.name, equals('Ping'));
-      expect(signal.values, equals([DBusString('Hello'), DBusUint32(42)]));
-    }));
+    var signals = DBusSignalStream(
+      client2,
+      interface: 'com.example.Test',
+      name: 'Ping',
+    );
+    signals.listen(
+      expectAsync1((signal) {
+        expect(signal.sender, equals(client1.uniqueName));
+        expect(signal.path, equals(DBusObjectPath('/')));
+        expect(signal.interface, equals('com.example.Test'));
+        expect(signal.name, equals('Ping'));
+        expect(signal.values, equals([DBusString('Hello'), DBusUint32(42)]));
+      }),
+    );
 
     // Do a round-trip to the server to ensure the signal has been subscribed to.
     await client2.ping();
 
     // Emit the signal.
-    await object.emitSignal(
-        'com.example.Test', 'Ping', [DBusString('Hello'), DBusUint32(42)]);
+    await object.emitSignal('com.example.Test', 'Ping', [
+      DBusString('Hello'),
+      DBusUint32(42),
+    ]);
   });
 
   test('subscribe signal - match signature', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3553,36 +4354,45 @@ void main() {
     await client1.registerObject(object);
 
     // Subscribe to the signal from another client.
-    var signals = DBusSignalStream(client2,
-        interface: 'com.example.Test',
-        name: 'Ping',
-        signature: DBusSignature('su'));
+    var signals = DBusSignalStream(
+      client2,
+      interface: 'com.example.Test',
+      name: 'Ping',
+      signature: DBusSignature('su'),
+    );
     expect(
-        signals,
-        emitsInOrder([
-          DBusSignal(
-              sender: client1.uniqueName,
-              path: DBusObjectPath('/'),
-              interface: 'com.example.Test',
-              name: 'Ping',
-              values: [DBusString('Hello'), DBusUint32(42)]),
-          emitsError(isA<DBusSignalSignatureException>())
-        ]));
+      signals,
+      emitsInOrder([
+        DBusSignal(
+          sender: client1.uniqueName,
+          path: DBusObjectPath('/'),
+          interface: 'com.example.Test',
+          name: 'Ping',
+          values: [DBusString('Hello'), DBusUint32(42)],
+        ),
+        emitsError(isA<DBusSignalSignatureException>()),
+      ]),
+    );
 
     // Do a round-trip to the server to ensure the signal has been subscribed to.
     await client2.ping();
 
     // Emit one signal with correct signature, one without
-    await object.emitSignal(
-        'com.example.Test', 'Ping', [DBusString('Hello'), DBusUint32(42)]);
-    await object.emitSignal(
-        'com.example.Test', 'Ping', [DBusUint32(42), DBusString('Hello')]);
+    await object.emitSignal('com.example.Test', 'Ping', [
+      DBusString('Hello'),
+      DBusUint32(42),
+    ]);
+    await object.emitSignal('com.example.Test', 'Ping', [
+      DBusUint32(42),
+      DBusString('Hello'),
+    ]);
   });
 
   test('subscribe signal - remote object', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3596,30 +4406,41 @@ void main() {
     await client1.registerObject(object);
 
     // Subscribe to the signal from another client.
-    var remoteObject = DBusRemoteObject(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
+    var remoteObject = DBusRemoteObject(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
     var signals = DBusRemoteObjectSignalStream(
-        object: remoteObject, interface: 'com.example.Test', name: 'Ping');
-    signals.listen(expectAsync1((signal) {
-      expect(signal.sender, equals(client1.uniqueName));
-      expect(signal.path, equals(DBusObjectPath('/')));
-      expect(signal.interface, equals('com.example.Test'));
-      expect(signal.name, equals('Ping'));
-      expect(signal.values, equals([DBusString('Hello'), DBusUint32(42)]));
-    }));
+      object: remoteObject,
+      interface: 'com.example.Test',
+      name: 'Ping',
+    );
+    signals.listen(
+      expectAsync1((signal) {
+        expect(signal.sender, equals(client1.uniqueName));
+        expect(signal.path, equals(DBusObjectPath('/')));
+        expect(signal.interface, equals('com.example.Test'));
+        expect(signal.name, equals('Ping'));
+        expect(signal.values, equals([DBusString('Hello'), DBusUint32(42)]));
+      }),
+    );
 
     // Do a round-trip to the server to ensure the signal has been subscribed to.
     await client2.ping();
 
     // Emit the signal.
-    await object.emitSignal(
-        'com.example.Test', 'Ping', [DBusString('Hello'), DBusUint32(42)]);
+    await object.emitSignal('com.example.Test', 'Ping', [
+      DBusString('Hello'),
+      DBusUint32(42),
+    ]);
   });
 
   test('subscribe signal - remote object - match signature', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3633,39 +4454,50 @@ void main() {
     await client1.registerObject(object);
 
     // Subscribe to the signal from another client.
-    var remoteObject = DBusRemoteObject(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
+    var remoteObject = DBusRemoteObject(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
     var signals = DBusRemoteObjectSignalStream(
-        object: remoteObject,
-        interface: 'com.example.Test',
-        name: 'Ping',
-        signature: DBusSignature('su'));
+      object: remoteObject,
+      interface: 'com.example.Test',
+      name: 'Ping',
+      signature: DBusSignature('su'),
+    );
     expect(
-        signals,
-        emitsInOrder([
-          DBusSignal(
-              sender: client1.uniqueName,
-              path: DBusObjectPath('/'),
-              interface: 'com.example.Test',
-              name: 'Ping',
-              values: [DBusString('Hello'), DBusUint32(42)]),
-          emitsError(isA<DBusSignalSignatureException>())
-        ]));
+      signals,
+      emitsInOrder([
+        DBusSignal(
+          sender: client1.uniqueName,
+          path: DBusObjectPath('/'),
+          interface: 'com.example.Test',
+          name: 'Ping',
+          values: [DBusString('Hello'), DBusUint32(42)],
+        ),
+        emitsError(isA<DBusSignalSignatureException>()),
+      ]),
+    );
 
     // Do a round-trip to the server to ensure the signal has been subscribed to.
     await client2.ping();
 
     // Emit one signal with correct signature, one without
-    await object.emitSignal(
-        'com.example.Test', 'Ping', [DBusString('Hello'), DBusUint32(42)]);
-    await object.emitSignal(
-        'com.example.Test', 'Ping', [DBusUint32(42), DBusString('Hello')]);
+    await object.emitSignal('com.example.Test', 'Ping', [
+      DBusString('Hello'),
+      DBusUint32(42),
+    ]);
+    await object.emitSignal('com.example.Test', 'Ping', [
+      DBusUint32(42),
+      DBusString('Hello'),
+    ]);
   });
 
   test('subscribe signal - remote named object', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3680,30 +4512,41 @@ void main() {
     await client1.registerObject(object);
 
     // Subscribe to the signal from another client.
-    var remoteObject = DBusRemoteObject(client2,
-        name: 'com.example.Test', path: DBusObjectPath('/'));
+    var remoteObject = DBusRemoteObject(
+      client2,
+      name: 'com.example.Test',
+      path: DBusObjectPath('/'),
+    );
     var signals = DBusRemoteObjectSignalStream(
-        object: remoteObject, interface: 'com.example.Test', name: 'Ping');
-    signals.listen(expectAsync1((signal) {
-      expect(signal.sender, equals(client1.uniqueName));
-      expect(signal.path, equals(DBusObjectPath('/')));
-      expect(signal.interface, equals('com.example.Test'));
-      expect(signal.name, equals('Ping'));
-      expect(signal.values, equals([DBusString('Hello'), DBusUint32(42)]));
-    }));
+      object: remoteObject,
+      interface: 'com.example.Test',
+      name: 'Ping',
+    );
+    signals.listen(
+      expectAsync1((signal) {
+        expect(signal.sender, equals(client1.uniqueName));
+        expect(signal.path, equals(DBusObjectPath('/')));
+        expect(signal.interface, equals('com.example.Test'));
+        expect(signal.name, equals('Ping'));
+        expect(signal.values, equals([DBusString('Hello'), DBusUint32(42)]));
+      }),
+    );
 
     // Do a round-trip to the server to ensure the signal has been subscribed to.
     await client2.ping();
 
     // Emit the signal.
-    await object.emitSignal(
-        'com.example.Test', 'Ping', [DBusString('Hello'), DBusUint32(42)]);
+    await object.emitSignal('com.example.Test', 'Ping', [
+      DBusString('Hello'),
+      DBusUint32(42),
+    ]);
   });
 
   test('signal from method call', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3719,13 +4562,21 @@ void main() {
     // Subscribe to the signal from another client.
     // Check that the signal is recived before the method call response completes.
     var methodCallDone = false;
-    var remoteObject = DBusRemoteObject(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
+    var remoteObject = DBusRemoteObject(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
     var signals = DBusRemoteObjectSignalStream(
-        object: remoteObject, interface: 'com.example.Test', name: 'Event');
-    signals.listen(expectAsync1((signal) {
-      expect(methodCallDone, isFalse);
-    }));
+      object: remoteObject,
+      interface: 'com.example.Test',
+      name: 'Event',
+    );
+    signals.listen(
+      expectAsync1((signal) {
+        expect(methodCallDone, isFalse);
+      }),
+    );
 
     // Make the method call that will emit the signal.
     await remoteObject.callMethod('com.example.Test', 'EmitEvent', []);
@@ -3734,8 +4585,9 @@ void main() {
 
   test('matches - invalid args', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -3743,66 +4595,81 @@ void main() {
     });
 
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'AddMatch'),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'AddMatch',
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'AddMatch',
-            values: [DBusUint32(42)]),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'AddMatch',
+        values: [DBusUint32(42)],
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'AddMatch',
-            values: [DBusString('No a valid match')]),
-        throwsA(isA<DBusErrorException>()));
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'AddMatch',
+        values: [DBusString('No a valid match')],
+      ),
+      throwsA(isA<DBusErrorException>()),
+    );
 
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'RemoveMatch'),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'RemoveMatch',
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'RemoveMatch',
-            values: [DBusUint32(42)]),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'RemoveMatch',
+        values: [DBusUint32(42)],
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'RemoveMatch',
-            values: [DBusString('No a valid match')]),
-        throwsA(isA<DBusErrorException>()));
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'RemoveMatch',
+        values: [DBusString('No a valid match')],
+      ),
+      throwsA(isA<DBusErrorException>()),
+    );
     expect(
-        () => client.callMethod(
-            destination: 'org.freedesktop.DBus',
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus',
-            name: 'RemoveMatch',
-            values: [DBusString('type=signal,sender=not.a.real.Sender')]),
-        throwsA(isA<DBusErrorException>()));
+      () => client.callMethod(
+        destination: 'org.freedesktop.DBus',
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus',
+        name: 'RemoveMatch',
+        values: [DBusString('type=signal,sender=not.a.real.Sender')],
+      ),
+      throwsA(isA<DBusErrorException>()),
+    );
   });
 
   test('introspect - server', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
@@ -3810,122 +4677,129 @@ void main() {
     });
 
     // Read introspection data from the server.
-    var remoteObject = DBusRemoteObject(client,
-        name: 'org.freedesktop.DBus', path: DBusObjectPath('/'));
+    var remoteObject = DBusRemoteObject(
+      client,
+      name: 'org.freedesktop.DBus',
+      path: DBusObjectPath('/'),
+    );
     var node = await remoteObject.introspect();
     expect(
-        node.toXml().toXmlString(),
-        equals('<node>'
-            '<interface name="org.freedesktop.DBus.Introspectable">'
-            '<method name="Introspect">'
-            '<arg name="xml_data" type="s" direction="out"/>'
-            '</method>'
-            '</interface>'
-            '<interface name="org.freedesktop.DBus.Peer">'
-            '<method name="GetMachineId">'
-            '<arg name="machine_uuid" type="s" direction="out"/>'
-            '</method>'
-            '<method name="Ping"/>'
-            '</interface>'
-            '<interface name="org.freedesktop.DBus.Properties">'
-            '<method name="Get">'
-            '<arg name="interface_name" type="s" direction="in"/>'
-            '<arg name="property_name" type="s" direction="in"/>'
-            '<arg name="value" type="v" direction="out"/>'
-            '</method>'
-            '<method name="Set">'
-            '<arg name="interface_name" type="s" direction="in"/>'
-            '<arg name="property_name" type="s" direction="in"/>'
-            '<arg name="value" type="v" direction="in"/>'
-            '</method>'
-            '<method name="GetAll">'
-            '<arg name="interface_name" type="s" direction="in"/>'
-            '<arg name="props" type="a{sv}" direction="out"/>'
-            '</method>'
-            '<signal name="PropertiesChanged">'
-            '<arg name="interface_name" type="s"/>'
-            '<arg name="changed_properties" type="a{sv}"/>'
-            '<arg name="invalidated_properties" type="as"/>'
-            '</signal>'
-            '</interface>'
-            '<interface name="org.freedesktop.DBus">'
-            '<method name="Hello">'
-            '<arg name="unique_name" type="s" direction="out"/>'
-            '</method>'
-            '<method name="RequestName">'
-            '<arg name="name" type="s" direction="in"/>'
-            '<arg name="flags" type="u" direction="in"/>'
-            '<arg name="result" type="u" direction="out"/>'
-            '</method>'
-            '<method name="ReleaseName">'
-            '<arg name="name" type="s" direction="in"/>'
-            '<arg name="result" type="u" direction="out"/>'
-            '</method>'
-            '<method name="ListQueuedOwners">'
-            '<arg name="name" type="s" direction="in"/>'
-            '<arg name="names" type="as" direction="out"/>'
-            '</method>'
-            '<method name="ListNames">'
-            '<arg name="names" type="as" direction="out"/>'
-            '</method>'
-            '<method name="ListActivatableNames">'
-            '<arg name="names" type="as" direction="out"/>'
-            '</method>'
-            '<method name="NameHasOwner">'
-            '<arg name="name" type="s" direction="in"/>'
-            '<arg name="result" type="b" direction="out"/>'
-            '</method>'
-            '<method name="StartServiceByName">'
-            '<arg name="name" type="s" direction="in"/>'
-            '<arg name="flags" type="u" direction="in"/>'
-            '<arg name="result" type="u" direction="out"/>'
-            '</method>'
-            '<method name="GetNameOwner">'
-            '<arg name="name" type="s" direction="in"/>'
-            '<arg name="owner" type="s" direction="out"/>'
-            '</method>'
-            '<method name="GetConnectionUnixUser">'
-            '<arg name="name" type="s" direction="in"/>'
-            '<arg name="unix_user_id" type="u" direction="out"/>'
-            '</method>'
-            '<method name="GetConnectionUnixProcessID">'
-            '<arg name="name" type="s" direction="in"/>'
-            '<arg name="unix_process_id" type="u" direction="out"/>'
-            '</method>'
-            '<method name="GetConnectionCredentials">'
-            '<arg name="name" type="s" direction="in"/>'
-            '<arg name="credentials" type="a{sv}" direction="out"/>'
-            '</method>'
-            '<method name="AddMatch">'
-            '<arg name="rule" type="s" direction="in"/>'
-            '</method>'
-            '<method name="RemoveMatch">'
-            '<arg name="rule" type="s" direction="in"/>'
-            '</method>'
-            '<method name="GetId">'
-            '<arg name="id" type="s" direction="out"/>'
-            '</method>'
-            '<signal name="NameOwnerChanged">'
-            '<arg name="name" type="s"/>'
-            '<arg name="old_owner" type="s"/>'
-            '<arg name="new_owner" type="s"/>'
-            '</signal>'
-            '<signal name="NameLost">'
-            '<arg name="name" type="s"/>'
-            '</signal>'
-            '<signal name="NameAcquired">'
-            '<arg name="name" type="s"/>'
-            '</signal>'
-            '<property name="Features" type="as" access="read"/>'
-            '<property name="Interfaces" type="as" access="read"/>'
-            '</interface>'
-            '</node>'));
+      node.toXml().toXmlString(),
+      equals(
+        '<node>'
+        '<interface name="org.freedesktop.DBus.Introspectable">'
+        '<method name="Introspect">'
+        '<arg name="xml_data" type="s" direction="out"/>'
+        '</method>'
+        '</interface>'
+        '<interface name="org.freedesktop.DBus.Peer">'
+        '<method name="GetMachineId">'
+        '<arg name="machine_uuid" type="s" direction="out"/>'
+        '</method>'
+        '<method name="Ping"/>'
+        '</interface>'
+        '<interface name="org.freedesktop.DBus.Properties">'
+        '<method name="Get">'
+        '<arg name="interface_name" type="s" direction="in"/>'
+        '<arg name="property_name" type="s" direction="in"/>'
+        '<arg name="value" type="v" direction="out"/>'
+        '</method>'
+        '<method name="Set">'
+        '<arg name="interface_name" type="s" direction="in"/>'
+        '<arg name="property_name" type="s" direction="in"/>'
+        '<arg name="value" type="v" direction="in"/>'
+        '</method>'
+        '<method name="GetAll">'
+        '<arg name="interface_name" type="s" direction="in"/>'
+        '<arg name="props" type="a{sv}" direction="out"/>'
+        '</method>'
+        '<signal name="PropertiesChanged">'
+        '<arg name="interface_name" type="s"/>'
+        '<arg name="changed_properties" type="a{sv}"/>'
+        '<arg name="invalidated_properties" type="as"/>'
+        '</signal>'
+        '</interface>'
+        '<interface name="org.freedesktop.DBus">'
+        '<method name="Hello">'
+        '<arg name="unique_name" type="s" direction="out"/>'
+        '</method>'
+        '<method name="RequestName">'
+        '<arg name="name" type="s" direction="in"/>'
+        '<arg name="flags" type="u" direction="in"/>'
+        '<arg name="result" type="u" direction="out"/>'
+        '</method>'
+        '<method name="ReleaseName">'
+        '<arg name="name" type="s" direction="in"/>'
+        '<arg name="result" type="u" direction="out"/>'
+        '</method>'
+        '<method name="ListQueuedOwners">'
+        '<arg name="name" type="s" direction="in"/>'
+        '<arg name="names" type="as" direction="out"/>'
+        '</method>'
+        '<method name="ListNames">'
+        '<arg name="names" type="as" direction="out"/>'
+        '</method>'
+        '<method name="ListActivatableNames">'
+        '<arg name="names" type="as" direction="out"/>'
+        '</method>'
+        '<method name="NameHasOwner">'
+        '<arg name="name" type="s" direction="in"/>'
+        '<arg name="result" type="b" direction="out"/>'
+        '</method>'
+        '<method name="StartServiceByName">'
+        '<arg name="name" type="s" direction="in"/>'
+        '<arg name="flags" type="u" direction="in"/>'
+        '<arg name="result" type="u" direction="out"/>'
+        '</method>'
+        '<method name="GetNameOwner">'
+        '<arg name="name" type="s" direction="in"/>'
+        '<arg name="owner" type="s" direction="out"/>'
+        '</method>'
+        '<method name="GetConnectionUnixUser">'
+        '<arg name="name" type="s" direction="in"/>'
+        '<arg name="unix_user_id" type="u" direction="out"/>'
+        '</method>'
+        '<method name="GetConnectionUnixProcessID">'
+        '<arg name="name" type="s" direction="in"/>'
+        '<arg name="unix_process_id" type="u" direction="out"/>'
+        '</method>'
+        '<method name="GetConnectionCredentials">'
+        '<arg name="name" type="s" direction="in"/>'
+        '<arg name="credentials" type="a{sv}" direction="out"/>'
+        '</method>'
+        '<method name="AddMatch">'
+        '<arg name="rule" type="s" direction="in"/>'
+        '</method>'
+        '<method name="RemoveMatch">'
+        '<arg name="rule" type="s" direction="in"/>'
+        '</method>'
+        '<method name="GetId">'
+        '<arg name="id" type="s" direction="out"/>'
+        '</method>'
+        '<signal name="NameOwnerChanged">'
+        '<arg name="name" type="s"/>'
+        '<arg name="old_owner" type="s"/>'
+        '<arg name="new_owner" type="s"/>'
+        '</signal>'
+        '<signal name="NameLost">'
+        '<arg name="name" type="s"/>'
+        '</signal>'
+        '<signal name="NameAcquired">'
+        '<arg name="name" type="s"/>'
+        '</signal>'
+        '<property name="Features" type="as" access="read"/>'
+        '<property name="Interfaces" type="as" access="read"/>'
+        '</interface>'
+        '</node>',
+      ),
+    );
   });
 
   test('introspect - client', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -3935,60 +4809,73 @@ void main() {
     });
 
     // Create a client that exposes introspection data.
-    await client1.registerObject(TestObject(introspectData: [
-      DBusIntrospectInterface('com.example.Test',
-          methods: [DBusIntrospectMethod('Foo')])
-    ]));
+    await client1.registerObject(
+      TestObject(
+        introspectData: [
+          DBusIntrospectInterface(
+            'com.example.Test',
+            methods: [DBusIntrospectMethod('Foo')],
+          ),
+        ],
+      ),
+    );
 
     // Read introspection data from the first client.
-    var remoteObject = DBusRemoteObject(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
+    var remoteObject = DBusRemoteObject(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
     var node = await remoteObject.introspect();
     expect(
-        node.toXml().toXmlString(),
-        equals('<node>'
-            '<interface name="org.freedesktop.DBus.Introspectable">'
-            '<method name="Introspect">'
-            '<arg name="xml_data" type="s" direction="out"/>'
-            '</method>'
-            '</interface>'
-            '<interface name="org.freedesktop.DBus.Peer">'
-            '<method name="GetMachineId">'
-            '<arg name="machine_uuid" type="s" direction="out"/>'
-            '</method>'
-            '<method name="Ping"/>'
-            '</interface>'
-            '<interface name="org.freedesktop.DBus.Properties">'
-            '<method name="Get">'
-            '<arg name="interface_name" type="s" direction="in"/>'
-            '<arg name="property_name" type="s" direction="in"/>'
-            '<arg name="value" type="v" direction="out"/>'
-            '</method>'
-            '<method name="Set">'
-            '<arg name="interface_name" type="s" direction="in"/>'
-            '<arg name="property_name" type="s" direction="in"/>'
-            '<arg name="value" type="v" direction="in"/>'
-            '</method>'
-            '<method name="GetAll">'
-            '<arg name="interface_name" type="s" direction="in"/>'
-            '<arg name="props" type="a{sv}" direction="out"/>'
-            '</method>'
-            '<signal name="PropertiesChanged">'
-            '<arg name="interface_name" type="s"/>'
-            '<arg name="changed_properties" type="a{sv}"/>'
-            '<arg name="invalidated_properties" type="as"/>'
-            '</signal>'
-            '</interface>'
-            '<interface name="com.example.Test">'
-            '<method name="Foo"/>'
-            '</interface>'
-            '</node>'));
+      node.toXml().toXmlString(),
+      equals(
+        '<node>'
+        '<interface name="org.freedesktop.DBus.Introspectable">'
+        '<method name="Introspect">'
+        '<arg name="xml_data" type="s" direction="out"/>'
+        '</method>'
+        '</interface>'
+        '<interface name="org.freedesktop.DBus.Peer">'
+        '<method name="GetMachineId">'
+        '<arg name="machine_uuid" type="s" direction="out"/>'
+        '</method>'
+        '<method name="Ping"/>'
+        '</interface>'
+        '<interface name="org.freedesktop.DBus.Properties">'
+        '<method name="Get">'
+        '<arg name="interface_name" type="s" direction="in"/>'
+        '<arg name="property_name" type="s" direction="in"/>'
+        '<arg name="value" type="v" direction="out"/>'
+        '</method>'
+        '<method name="Set">'
+        '<arg name="interface_name" type="s" direction="in"/>'
+        '<arg name="property_name" type="s" direction="in"/>'
+        '<arg name="value" type="v" direction="in"/>'
+        '</method>'
+        '<method name="GetAll">'
+        '<arg name="interface_name" type="s" direction="in"/>'
+        '<arg name="props" type="a{sv}" direction="out"/>'
+        '</method>'
+        '<signal name="PropertiesChanged">'
+        '<arg name="interface_name" type="s"/>'
+        '<arg name="changed_properties" type="a{sv}"/>'
+        '<arg name="invalidated_properties" type="as"/>'
+        '</signal>'
+        '</interface>'
+        '<interface name="com.example.Test">'
+        '<method name="Foo"/>'
+        '</interface>'
+        '</node>',
+      ),
+    );
   });
 
   test('introspect - empty object', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4001,51 +4888,58 @@ void main() {
     await client1.registerObject(DBusObject(DBusObjectPath('/')));
 
     // Read introspection data from the first client.
-    var remoteObject = DBusRemoteObject(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
+    var remoteObject = DBusRemoteObject(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
     var node = await remoteObject.introspect();
     expect(
-        node.toXml().toXmlString(),
-        equals('<node>'
-            '<interface name="org.freedesktop.DBus.Introspectable">'
-            '<method name="Introspect">'
-            '<arg name="xml_data" type="s" direction="out"/>'
-            '</method>'
-            '</interface>'
-            '<interface name="org.freedesktop.DBus.Peer">'
-            '<method name="GetMachineId">'
-            '<arg name="machine_uuid" type="s" direction="out"/>'
-            '</method>'
-            '<method name="Ping"/>'
-            '</interface>'
-            '<interface name="org.freedesktop.DBus.Properties">'
-            '<method name="Get">'
-            '<arg name="interface_name" type="s" direction="in"/>'
-            '<arg name="property_name" type="s" direction="in"/>'
-            '<arg name="value" type="v" direction="out"/>'
-            '</method>'
-            '<method name="Set">'
-            '<arg name="interface_name" type="s" direction="in"/>'
-            '<arg name="property_name" type="s" direction="in"/>'
-            '<arg name="value" type="v" direction="in"/>'
-            '</method>'
-            '<method name="GetAll">'
-            '<arg name="interface_name" type="s" direction="in"/>'
-            '<arg name="props" type="a{sv}" direction="out"/>'
-            '</method>'
-            '<signal name="PropertiesChanged">'
-            '<arg name="interface_name" type="s"/>'
-            '<arg name="changed_properties" type="a{sv}"/>'
-            '<arg name="invalidated_properties" type="as"/>'
-            '</signal>'
-            '</interface>'
-            '</node>'));
+      node.toXml().toXmlString(),
+      equals(
+        '<node>'
+        '<interface name="org.freedesktop.DBus.Introspectable">'
+        '<method name="Introspect">'
+        '<arg name="xml_data" type="s" direction="out"/>'
+        '</method>'
+        '</interface>'
+        '<interface name="org.freedesktop.DBus.Peer">'
+        '<method name="GetMachineId">'
+        '<arg name="machine_uuid" type="s" direction="out"/>'
+        '</method>'
+        '<method name="Ping"/>'
+        '</interface>'
+        '<interface name="org.freedesktop.DBus.Properties">'
+        '<method name="Get">'
+        '<arg name="interface_name" type="s" direction="in"/>'
+        '<arg name="property_name" type="s" direction="in"/>'
+        '<arg name="value" type="v" direction="out"/>'
+        '</method>'
+        '<method name="Set">'
+        '<arg name="interface_name" type="s" direction="in"/>'
+        '<arg name="property_name" type="s" direction="in"/>'
+        '<arg name="value" type="v" direction="in"/>'
+        '</method>'
+        '<method name="GetAll">'
+        '<arg name="interface_name" type="s" direction="in"/>'
+        '<arg name="props" type="a{sv}" direction="out"/>'
+        '</method>'
+        '<signal name="PropertiesChanged">'
+        '<arg name="interface_name" type="s"/>'
+        '<arg name="changed_properties" type="a{sv}"/>'
+        '<arg name="invalidated_properties" type="as"/>'
+        '</signal>'
+        '</interface>'
+        '</node>',
+      ),
+    );
   });
 
   test('introspect - not introspectable', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address, introspectable: false);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4055,22 +4949,34 @@ void main() {
     });
 
     // Create a client that exposes introspection data.
-    await client1.registerObject(TestObject(introspectData: [
-      DBusIntrospectInterface('com.example.Test',
-          methods: [DBusIntrospectMethod('Foo')])
-    ]));
+    await client1.registerObject(
+      TestObject(
+        introspectData: [
+          DBusIntrospectInterface(
+            'com.example.Test',
+            methods: [DBusIntrospectMethod('Foo')],
+          ),
+        ],
+      ),
+    );
 
     // Unable to read introspection data from the first client.
-    var remoteObject = DBusRemoteObject(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
-    expect(() => remoteObject.introspect(),
-        throwsA(isA<DBusUnknownInterfaceException>()));
+    var remoteObject = DBusRemoteObject(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
+    expect(
+      () => remoteObject.introspect(),
+      throwsA(isA<DBusUnknownInterfaceException>()),
+    );
   });
 
   test('peer - invalid args', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4083,27 +4989,32 @@ void main() {
     await client1.ping();
 
     expect(
-        () => client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus.Peer',
-            name: 'Ping',
-            values: [DBusString('Boo')]),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus.Peer',
+        name: 'Ping',
+        values: [DBusString('Boo')],
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
     expect(
-        () => client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus.Peer',
-            name: 'GetMachineId',
-            values: [DBusString('Boo')]),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus.Peer',
+        name: 'GetMachineId',
+        values: [DBusString('Boo')],
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
   });
 
   test('peer - unknown method', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4117,18 +5028,21 @@ void main() {
 
     // Try and access an unknown method on the Peer interface.
     expect(
-        () => client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus.Peer',
-            name: 'NoSuchMethod'),
-        throwsA(isA<DBusUnknownMethodException>()));
+      () => client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus.Peer',
+        name: 'NoSuchMethod',
+      ),
+      throwsA(isA<DBusUnknownMethodException>()),
+    );
   });
 
   test('introspect - unknown method', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4138,69 +5052,34 @@ void main() {
     });
 
     // Create a client that exposes introspection data.
-    await client1.registerObject(TestObject(introspectData: [
-      DBusIntrospectInterface('com.example.Test',
-          methods: [DBusIntrospectMethod('Foo')])
-    ]));
+    await client1.registerObject(
+      TestObject(
+        introspectData: [
+          DBusIntrospectInterface(
+            'com.example.Test',
+            methods: [DBusIntrospectMethod('Foo')],
+          ),
+        ],
+      ),
+    );
 
     // Try and access an unknown method on the properties interface.
     expect(
-        () => client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus.Introspectable',
-            name: 'NoSuchMethod'),
-        throwsA(isA<DBusUnknownMethodException>()));
+      () => client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus.Introspectable',
+        name: 'NoSuchMethod',
+      ),
+      throwsA(isA<DBusUnknownMethodException>()),
+    );
   });
 
   test('get property', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
-    var client1 = DBusClient(address);
-    var client2 = DBusClient(address);
-    addTearDown(() async {
-      await client1.close();
-      await client2.close();
-      await server.close();
-    });
-
-    // Create a client that exposes an object with properties.
-    var object = TestObject(propertyValues: {
-      'com.example.Test.ReadWrite': DBusString('RW'),
-      'com.example.Test.ReadOnly': DBusString('RO'),
-      'com.example.Test.WriteOnly': DBusString('WO')
-    }, propertyGetErrors: {
-      'com.example.Test.WriteOnly': DBusMethodErrorResponse.propertyWriteOnly()
-    }, propertySetErrors: {
-      'com.example.Test.ReadOnly': DBusMethodErrorResponse.propertyReadOnly(),
-    });
-    await client1.registerObject(object);
-
-    var remoteObject = DBusRemoteObject(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
-
-    // Get properties from another client.
-
-    var readWriteValue =
-        await remoteObject.getProperty('com.example.Test', 'ReadWrite');
-    expect(readWriteValue, equals(DBusString('RW')));
-
-    var readOnlyValue =
-        await remoteObject.getProperty('com.example.Test', 'ReadOnly');
-    expect(readOnlyValue, equals(DBusString('RO')));
-
-    expect(remoteObject.getProperty('com.example.Test', 'WriteOnly'),
-        throwsException);
-
-    expect(remoteObject.getProperty('com.example.Test', 'Unknown'),
-        throwsException);
-  });
-
-  test('get property - match signature', () async {
-    var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4211,28 +5090,101 @@ void main() {
 
     // Create a client that exposes an object with properties.
     var object = TestObject(
-        propertyValues: {'com.example.Test.Property': DBusString('Value')});
+      propertyValues: {
+        'com.example.Test.ReadWrite': DBusString('RW'),
+        'com.example.Test.ReadOnly': DBusString('RO'),
+        'com.example.Test.WriteOnly': DBusString('WO'),
+      },
+      propertyGetErrors: {
+        'com.example.Test.WriteOnly':
+            DBusMethodErrorResponse.propertyWriteOnly(),
+      },
+      propertySetErrors: {
+        'com.example.Test.ReadOnly': DBusMethodErrorResponse.propertyReadOnly(),
+      },
+    );
     await client1.registerObject(object);
 
-    var remoteObject = DBusRemoteObject(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
+    var remoteObject = DBusRemoteObject(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
+
+    // Get properties from another client.
+
+    var readWriteValue = await remoteObject.getProperty(
+      'com.example.Test',
+      'ReadWrite',
+    );
+    expect(readWriteValue, equals(DBusString('RW')));
+
+    var readOnlyValue = await remoteObject.getProperty(
+      'com.example.Test',
+      'ReadOnly',
+    );
+    expect(readOnlyValue, equals(DBusString('RO')));
+
+    expect(
+      remoteObject.getProperty('com.example.Test', 'WriteOnly'),
+      throwsException,
+    );
+
+    expect(
+      remoteObject.getProperty('com.example.Test', 'Unknown'),
+      throwsException,
+    );
+  });
+
+  test('get property - match signature', () async {
+    var server = DBusServer();
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
+    var client1 = DBusClient(address);
+    var client2 = DBusClient(address);
+    addTearDown(() async {
+      await client1.close();
+      await client2.close();
+      await server.close();
+    });
+
+    // Create a client that exposes an object with properties.
+    var object = TestObject(
+      propertyValues: {'com.example.Test.Property': DBusString('Value')},
+    );
+    await client1.registerObject(object);
+
+    var remoteObject = DBusRemoteObject(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
 
     // Get properties and check they match expected signature.
     expect(
-        await remoteObject.getProperty('com.example.Test', 'Property',
-            signature: DBusSignature('s')),
-        equals(DBusString('Value')));
+      await remoteObject.getProperty(
+        'com.example.Test',
+        'Property',
+        signature: DBusSignature('s'),
+      ),
+      equals(DBusString('Value')),
+    );
     expect(
-        () async => await remoteObject.getProperty(
-            'com.example.Test', 'Property',
-            signature: DBusSignature('i')),
-        throwsA(isA<DBusPropertySignatureException>()));
+      () async => await remoteObject.getProperty(
+        'com.example.Test',
+        'Property',
+        signature: DBusSignature('i'),
+      ),
+      throwsA(isA<DBusPropertySignatureException>()),
+    );
   });
 
   test('set property', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4242,42 +5194,65 @@ void main() {
     });
 
     // Create a client that exposes an object with properties.
-    var object = TestObject(propertyValues: {
-      'com.example.Test.ReadWrite': DBusString(''),
-      'com.example.Test.ReadOnly': DBusString(''),
-      'com.example.Test.WriteOnly': DBusString('')
-    }, propertyGetErrors: {
-      'com.example.Test.WriteOnly': DBusMethodErrorResponse.propertyWriteOnly()
-    }, propertySetErrors: {
-      'com.example.Test.ReadOnly': DBusMethodErrorResponse.propertyReadOnly(),
-    });
+    var object = TestObject(
+      propertyValues: {
+        'com.example.Test.ReadWrite': DBusString(''),
+        'com.example.Test.ReadOnly': DBusString(''),
+        'com.example.Test.WriteOnly': DBusString(''),
+      },
+      propertyGetErrors: {
+        'com.example.Test.WriteOnly':
+            DBusMethodErrorResponse.propertyWriteOnly(),
+      },
+      propertySetErrors: {
+        'com.example.Test.ReadOnly': DBusMethodErrorResponse.propertyReadOnly(),
+      },
+    );
     await client1.registerObject(object);
 
-    var remoteObject = DBusRemoteObject(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
+    var remoteObject = DBusRemoteObject(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
 
     // Set properties from another client.
 
     await remoteObject.setProperty(
-        'com.example.Test', 'ReadWrite', DBusString('RW'));
-    expect(object.propertyValues['com.example.Test.ReadWrite'],
-        equals(DBusString('RW')));
+      'com.example.Test',
+      'ReadWrite',
+      DBusString('RW'),
+    );
+    expect(
+      object.propertyValues['com.example.Test.ReadWrite'],
+      equals(DBusString('RW')),
+    );
 
     expect(
-        remoteObject.setProperty(
-            'com.example.Test', 'ReadOnly', DBusString('RO')),
-        throwsException);
+      remoteObject.setProperty(
+        'com.example.Test',
+        'ReadOnly',
+        DBusString('RO'),
+      ),
+      throwsException,
+    );
 
     await remoteObject.setProperty(
-        'com.example.Test', 'WriteOnly', DBusString('WO'));
-    expect(object.propertyValues['com.example.Test.WriteOnly'],
-        equals(DBusString('WO')));
+      'com.example.Test',
+      'WriteOnly',
+      DBusString('WO'),
+    );
+    expect(
+      object.propertyValues['com.example.Test.WriteOnly'],
+      equals(DBusString('WO')),
+    );
   });
 
   test('get all properties', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4287,28 +5262,35 @@ void main() {
     });
 
     // Create a client that exposes an object with properties.
-    var object = TestObject(propertyValues: {
-      'com.example.Test.Property1': DBusString('VALUE1'),
-      'com.example.Test.Property2': DBusString('VALUE2')
-    });
+    var object = TestObject(
+      propertyValues: {
+        'com.example.Test.Property1': DBusString('VALUE1'),
+        'com.example.Test.Property2': DBusString('VALUE2'),
+      },
+    );
     await client1.registerObject(object);
 
-    var remoteObject = DBusRemoteObject(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
+    var remoteObject = DBusRemoteObject(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
 
     var properties = await remoteObject.getAllProperties('com.example.Test');
     expect(
-        properties,
-        equals({
-          'Property1': DBusString('VALUE1'),
-          'Property2': DBusString('VALUE2')
-        }));
+      properties,
+      equals({
+        'Property1': DBusString('VALUE1'),
+        'Property2': DBusString('VALUE2'),
+      }),
+    );
   });
 
   test('properties changed', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4322,35 +5304,43 @@ void main() {
     await client1.registerObject(object);
 
     /// Subscribe to properties changed signals.
-    var remoteObject = DBusRemoteObject(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
-    remoteObject.propertiesChanged.listen(expectAsync1((signal) {
-      expect(signal.propertiesInterface, equals('com.example.Test'));
-      expect(
+    var remoteObject = DBusRemoteObject(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
+    remoteObject.propertiesChanged.listen(
+      expectAsync1((signal) {
+        expect(signal.propertiesInterface, equals('com.example.Test'));
+        expect(
           signal.changedProperties,
           equals({
             'Property1': DBusString('VALUE1'),
-            'Property2': DBusString('VALUE2')
-          }));
-      expect(signal.invalidatedProperties, equals(['Invalid1', 'Invalid2']));
-    }));
+            'Property2': DBusString('VALUE2'),
+          }),
+        );
+        expect(signal.invalidatedProperties, equals(['Invalid1', 'Invalid2']));
+      }),
+    );
 
     // Do a round-trip to the server to ensure the signal has been subscribed to.
     await client2.ping();
 
-    await object.emitPropertiesChanged('com.example.Test', changedProperties: {
-      'Property1': DBusString('VALUE1'),
-      'Property2': DBusString('VALUE2')
-    }, invalidatedProperties: [
-      'Invalid1',
-      'Invalid2'
-    ]);
+    await object.emitPropertiesChanged(
+      'com.example.Test',
+      changedProperties: {
+        'Property1': DBusString('VALUE1'),
+        'Property2': DBusString('VALUE2'),
+      },
+      invalidatedProperties: ['Invalid1', 'Invalid2'],
+    );
   });
 
   test('properties - invalid args', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4365,32 +5355,39 @@ void main() {
 
     // Try and access methods with invalid args on the properties interface.
     expect(
-        () => client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus.Properties',
-            name: 'Get'),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus.Properties',
+        name: 'Get',
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
     expect(
-        () => client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus.Properties',
-            name: 'Set'),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus.Properties',
+        name: 'Set',
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
     expect(
-        () => client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus.Properties',
-            name: 'GetAll'),
-        throwsA(isA<DBusInvalidArgsException>()));
+      () => client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus.Properties',
+        name: 'GetAll',
+      ),
+      throwsA(isA<DBusInvalidArgsException>()),
+    );
   });
 
   test('properties - empty object', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4402,22 +5399,32 @@ void main() {
     // Create a client that exposes an object with no properties.
     await client1.registerObject(DBusObject(DBusObjectPath('/')));
 
-    var remoteObject = DBusRemoteObject(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
-    expect(() => remoteObject.getProperty('com.example.Test', 'Property'),
-        throwsA(isA<DBusUnknownPropertyException>()));
+    var remoteObject = DBusRemoteObject(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
     expect(
-        () => remoteObject.setProperty(
-            'com.example.Test', 'Property', DBusString('Foo')),
-        throwsA(isA<DBusUnknownPropertyException>()));
+      () => remoteObject.getProperty('com.example.Test', 'Property'),
+      throwsA(isA<DBusUnknownPropertyException>()),
+    );
+    expect(
+      () => remoteObject.setProperty(
+        'com.example.Test',
+        'Property',
+        DBusString('Foo'),
+      ),
+      throwsA(isA<DBusUnknownPropertyException>()),
+    );
     var properties = await remoteObject.getAllProperties('com.example.Test');
     expect(properties, isEmpty);
   });
 
   test('properties - unknown method', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4432,55 +5439,76 @@ void main() {
 
     // Try and access an unknown method on the properties interface.
     expect(
-        () => client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus.Properties',
-            name: 'NoSuchMethod'),
-        throwsA(isA<DBusUnknownMethodException>()));
+      () => client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus.Properties',
+        name: 'NoSuchMethod',
+      ),
+      throwsA(isA<DBusUnknownMethodException>()),
+    );
   });
 
   test('server properties', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address);
     addTearDown(() async {
       await client.close();
       await server.close();
     });
 
-    var remoteObject = DBusRemoteObject(client,
-        name: 'org.freedesktop.DBus', path: DBusObjectPath('/'));
+    var remoteObject = DBusRemoteObject(
+      client,
+      name: 'org.freedesktop.DBus',
+      path: DBusObjectPath('/'),
+    );
 
-    expect(await remoteObject.getProperty('org.freedesktop.DBus', 'Features'),
-        equals(DBusArray.string([])));
     expect(
-        remoteObject.setProperty(
-            'org.freedesktop.DBus', 'Features', DBusArray.string(['abc'])),
-        throwsException);
+      await remoteObject.getProperty('org.freedesktop.DBus', 'Features'),
+      equals(DBusArray.string([])),
+    );
+    expect(
+      remoteObject.setProperty(
+        'org.freedesktop.DBus',
+        'Features',
+        DBusArray.string(['abc']),
+      ),
+      throwsException,
+    );
 
-    expect(await remoteObject.getProperty('org.freedesktop.DBus', 'Interfaces'),
-        equals(DBusArray.string([])));
     expect(
-        remoteObject.setProperty(
-            'org.freedesktop.DBus', 'Interfaces', DBusArray.string(['abc'])),
-        throwsException);
+      await remoteObject.getProperty('org.freedesktop.DBus', 'Interfaces'),
+      equals(DBusArray.string([])),
+    );
+    expect(
+      remoteObject.setProperty(
+        'org.freedesktop.DBus',
+        'Interfaces',
+        DBusArray.string(['abc']),
+      ),
+      throwsException,
+    );
 
-    var properties =
-        await remoteObject.getAllProperties('org.freedesktop.DBus');
+    var properties = await remoteObject.getAllProperties(
+      'org.freedesktop.DBus',
+    );
     expect(
-        properties,
-        equals({
-          'Features': DBusArray.string([]),
-          'Interfaces': DBusArray.string([])
-        }));
+      properties,
+      equals({
+        'Features': DBusArray.string([]),
+        'Interfaces': DBusArray.string([]),
+      }),
+    );
   });
 
   test('object manager', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4490,44 +5518,56 @@ void main() {
     });
 
     // Register an object manager and a few objects with properties.
-    await client1
-        .registerObject(DBusObject(DBusObjectPath('/'), isObjectManager: true));
-    await client1.registerObject(TestObject(
+    await client1.registerObject(
+      DBusObject(DBusObjectPath('/'), isObjectManager: true),
+    );
+    await client1.registerObject(
+      TestObject(
         path: DBusObjectPath('/com/example/Object1'),
         interfacesAndProperties_: {
-          'com.example.Interface1': {'number': DBusUint32(1)}
-        }));
-    await client1.registerObject(TestObject(
+          'com.example.Interface1': {'number': DBusUint32(1)},
+        },
+      ),
+    );
+    await client1.registerObject(
+      TestObject(
         path: DBusObjectPath('/com/example/Object2'),
         interfacesAndProperties_: {
           'com.example.Interface1': {'number': DBusUint32(2)},
-          'com.example.Interface2': {'value': DBusString('FOO')}
-        }));
+          'com.example.Interface2': {'value': DBusString('FOO')},
+        },
+      ),
+    );
 
-    var remoteManagerObject = DBusRemoteObjectManager(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
+    var remoteManagerObject = DBusRemoteObjectManager(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
     var objects = await remoteManagerObject.getManagedObjects();
     expect(
-        objects,
-        equals({
-          DBusObjectPath('/com/example/Object1'): {
-            'org.freedesktop.DBus.Introspectable': {},
-            'org.freedesktop.DBus.Properties': {},
-            'com.example.Interface1': {'number': DBusUint32(1)}
-          },
-          DBusObjectPath('/com/example/Object2'): {
-            'org.freedesktop.DBus.Introspectable': {},
-            'org.freedesktop.DBus.Properties': {},
-            'com.example.Interface1': {'number': DBusUint32(2)},
-            'com.example.Interface2': {'value': DBusString('FOO')}
-          }
-        }));
+      objects,
+      equals({
+        DBusObjectPath('/com/example/Object1'): {
+          'org.freedesktop.DBus.Introspectable': {},
+          'org.freedesktop.DBus.Properties': {},
+          'com.example.Interface1': {'number': DBusUint32(1)},
+        },
+        DBusObjectPath('/com/example/Object2'): {
+          'org.freedesktop.DBus.Introspectable': {},
+          'org.freedesktop.DBus.Properties': {},
+          'com.example.Interface1': {'number': DBusUint32(2)},
+          'com.example.Interface2': {'value': DBusString('FOO')},
+        },
+      }),
+    );
   });
 
   test('object manager - no interfaces', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4537,28 +5577,35 @@ void main() {
     });
 
     // Register an object manager and an object without any interfaces other than the standard ones.
-    await client1
-        .registerObject(DBusObject(DBusObjectPath('/'), isObjectManager: true));
     await client1.registerObject(
-        TestObject(path: DBusObjectPath('/com/example/Object')));
+      DBusObject(DBusObjectPath('/'), isObjectManager: true),
+    );
+    await client1.registerObject(
+      TestObject(path: DBusObjectPath('/com/example/Object')),
+    );
 
-    var remoteManagerObject = DBusRemoteObjectManager(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
+    var remoteManagerObject = DBusRemoteObjectManager(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
     var objects = await remoteManagerObject.getManagedObjects();
     expect(
-        objects,
-        equals({
-          DBusObjectPath('/com/example/Object'): {
-            'org.freedesktop.DBus.Introspectable': {},
-            'org.freedesktop.DBus.Properties': {}
-          }
-        }));
+      objects,
+      equals({
+        DBusObjectPath('/com/example/Object'): {
+          'org.freedesktop.DBus.Introspectable': {},
+          'org.freedesktop.DBus.Properties': {},
+        },
+      }),
+    );
   });
 
   test('object manager - introspect', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4568,71 +5615,80 @@ void main() {
     });
 
     // Register an object manager and an object without any interfaces other than the standard ones.
-    await client1
-        .registerObject(DBusObject(DBusObjectPath('/'), isObjectManager: true));
     await client1.registerObject(
-        TestObject(path: DBusObjectPath('/com/example/Object')));
+      DBusObject(DBusObjectPath('/'), isObjectManager: true),
+    );
+    await client1.registerObject(
+      TestObject(path: DBusObjectPath('/com/example/Object')),
+    );
 
     // Read introspection data from the first client.
-    var remoteObject = DBusRemoteObject(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
+    var remoteObject = DBusRemoteObject(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
     var node = await remoteObject.introspect();
     expect(
-        node.toXml().toXmlString(),
-        equals('<node>'
-            '<interface name="org.freedesktop.DBus.Introspectable">'
-            '<method name="Introspect">'
-            '<arg name="xml_data" type="s" direction="out"/>'
-            '</method>'
-            '</interface>'
-            '<interface name="org.freedesktop.DBus.Peer">'
-            '<method name="GetMachineId">'
-            '<arg name="machine_uuid" type="s" direction="out"/>'
-            '</method>'
-            '<method name="Ping"/>'
-            '</interface>'
-            '<interface name="org.freedesktop.DBus.Properties">'
-            '<method name="Get">'
-            '<arg name="interface_name" type="s" direction="in"/>'
-            '<arg name="property_name" type="s" direction="in"/>'
-            '<arg name="value" type="v" direction="out"/>'
-            '</method>'
-            '<method name="Set">'
-            '<arg name="interface_name" type="s" direction="in"/>'
-            '<arg name="property_name" type="s" direction="in"/>'
-            '<arg name="value" type="v" direction="in"/>'
-            '</method>'
-            '<method name="GetAll">'
-            '<arg name="interface_name" type="s" direction="in"/>'
-            '<arg name="props" type="a{sv}" direction="out"/>'
-            '</method>'
-            '<signal name="PropertiesChanged">'
-            '<arg name="interface_name" type="s"/>'
-            '<arg name="changed_properties" type="a{sv}"/>'
-            '<arg name="invalidated_properties" type="as"/>'
-            '</signal>'
-            '</interface>'
-            '<interface name="org.freedesktop.DBus.ObjectManager">'
-            '<method name="GetManagedObjects">'
-            '<arg name="objpath_interfaces_and_properties" type="a{oa{sa{sv}}}" direction="out"/>'
-            '</method>'
-            '<signal name="InterfacesAdded">'
-            '<arg name="object_path" type="o"/>'
-            '<arg name="interfaces_and_properties" type="a{sa{sv}}"/>'
-            '</signal>'
-            '<signal name="InterfacesRemoved">'
-            '<arg name="object_path" type="o"/>'
-            '<arg name="interfaces" type="as"/>'
-            '</signal>'
-            '</interface>'
-            '<node name="com"/>'
-            '</node>'));
+      node.toXml().toXmlString(),
+      equals(
+        '<node>'
+        '<interface name="org.freedesktop.DBus.Introspectable">'
+        '<method name="Introspect">'
+        '<arg name="xml_data" type="s" direction="out"/>'
+        '</method>'
+        '</interface>'
+        '<interface name="org.freedesktop.DBus.Peer">'
+        '<method name="GetMachineId">'
+        '<arg name="machine_uuid" type="s" direction="out"/>'
+        '</method>'
+        '<method name="Ping"/>'
+        '</interface>'
+        '<interface name="org.freedesktop.DBus.Properties">'
+        '<method name="Get">'
+        '<arg name="interface_name" type="s" direction="in"/>'
+        '<arg name="property_name" type="s" direction="in"/>'
+        '<arg name="value" type="v" direction="out"/>'
+        '</method>'
+        '<method name="Set">'
+        '<arg name="interface_name" type="s" direction="in"/>'
+        '<arg name="property_name" type="s" direction="in"/>'
+        '<arg name="value" type="v" direction="in"/>'
+        '</method>'
+        '<method name="GetAll">'
+        '<arg name="interface_name" type="s" direction="in"/>'
+        '<arg name="props" type="a{sv}" direction="out"/>'
+        '</method>'
+        '<signal name="PropertiesChanged">'
+        '<arg name="interface_name" type="s"/>'
+        '<arg name="changed_properties" type="a{sv}"/>'
+        '<arg name="invalidated_properties" type="as"/>'
+        '</signal>'
+        '</interface>'
+        '<interface name="org.freedesktop.DBus.ObjectManager">'
+        '<method name="GetManagedObjects">'
+        '<arg name="objpath_interfaces_and_properties" type="a{oa{sa{sv}}}" direction="out"/>'
+        '</method>'
+        '<signal name="InterfacesAdded">'
+        '<arg name="object_path" type="o"/>'
+        '<arg name="interfaces_and_properties" type="a{sa{sv}}"/>'
+        '</signal>'
+        '<signal name="InterfacesRemoved">'
+        '<arg name="object_path" type="o"/>'
+        '<arg name="interfaces" type="as"/>'
+        '</signal>'
+        '</interface>'
+        '<node name="com"/>'
+        '</node>',
+      ),
+    );
   });
 
   test('object manager - not introspectable', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address, introspectable: false);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4642,27 +5698,34 @@ void main() {
     });
 
     // Register an object manager and one object. The client doesn't support introspection.
-    await client1
-        .registerObject(DBusObject(DBusObjectPath('/'), isObjectManager: true));
     await client1.registerObject(
-        TestObject(path: DBusObjectPath('/com/example/Object')));
+      DBusObject(DBusObjectPath('/'), isObjectManager: true),
+    );
+    await client1.registerObject(
+      TestObject(path: DBusObjectPath('/com/example/Object')),
+    );
 
-    var remoteManagerObject = DBusRemoteObjectManager(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
+    var remoteManagerObject = DBusRemoteObjectManager(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
     var objects = await remoteManagerObject.getManagedObjects();
     expect(
-        objects,
-        equals({
-          DBusObjectPath('/com/example/Object'): {
-            'org.freedesktop.DBus.Properties': {}
-          }
-        }));
+      objects,
+      equals({
+        DBusObjectPath('/com/example/Object'): {
+          'org.freedesktop.DBus.Properties': {},
+        },
+      }),
+    );
   });
 
   test('object manager - object added', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4675,46 +5738,59 @@ void main() {
     var objectManager = DBusObject(DBusObjectPath('/'), isObjectManager: true);
     await client1.registerObject(objectManager);
     await client1.registerObject(
-        TestObject(path: DBusObjectPath('/com/example/Object1')));
+      TestObject(path: DBusObjectPath('/com/example/Object1')),
+    );
 
     // Subscribe to object manager signals.
-    var remoteManagerObject = DBusRemoteObjectManager(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
-    remoteManagerObject.signals.listen(expectAsync1((signal) {
-      expect(signal, TypeMatcher<DBusObjectManagerInterfacesAddedSignal>());
-      var interfacesAdded = signal as DBusObjectManagerInterfacesAddedSignal;
-      expect(interfacesAdded.changedPath,
-          equals(DBusObjectPath('/com/example/Object2')));
-      expect(
+    var remoteManagerObject = DBusRemoteObjectManager(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
+    remoteManagerObject.signals.listen(
+      expectAsync1((signal) {
+        expect(signal, TypeMatcher<DBusObjectManagerInterfacesAddedSignal>());
+        var interfacesAdded = signal as DBusObjectManagerInterfacesAddedSignal;
+        expect(
+          interfacesAdded.changedPath,
+          equals(DBusObjectPath('/com/example/Object2')),
+        );
+        expect(
           interfacesAdded.interfacesAndProperties,
           equals({
             'org.freedesktop.DBus.Introspectable': {},
             'org.freedesktop.DBus.Properties': {},
             'com.example.Interface': {
               'Property1': DBusString('VALUE1'),
-              'Property2': DBusString('VALUE2')
-            }
-          }));
-    }));
+              'Property2': DBusString('VALUE2'),
+            },
+          }),
+        );
+      }),
+    );
 
     // Do a round-trip to the server to ensure the signal has been subscribed to.
     await client2.ping();
 
     // Add a second object.
-    await client1.registerObject(TestObject(
+    await client1.registerObject(
+      TestObject(
         path: DBusObjectPath('/com/example/Object2'),
         interfacesAndProperties_: {
           'com.example.Interface': {
             'Property1': DBusString('VALUE1'),
-            'Property2': DBusString('VALUE2')
-          }
-        }));
+            'Property2': DBusString('VALUE2'),
+          },
+        },
+      ),
+    );
   });
 
   test('object manager - object removed', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4727,35 +5803,45 @@ void main() {
     var objectManager = DBusObject(DBusObjectPath('/'), isObjectManager: true);
     await client1.registerObject(objectManager);
     await client1.registerObject(
-        TestObject(path: DBusObjectPath('/com/example/Object1')));
+      TestObject(path: DBusObjectPath('/com/example/Object1')),
+    );
     var object2 = TestObject(
-        path: DBusObjectPath('/com/example/Object2'),
-        interfacesAndProperties_: {
-          'org.freedesktop.DBus.Introspectable': {},
-          'org.freedesktop.DBus.Properties': {},
-          'com.example.Interface1': {'number': DBusUint32(2)},
-          'com.example.Interface2': {'value': DBusString('FOO')}
-        });
+      path: DBusObjectPath('/com/example/Object2'),
+      interfacesAndProperties_: {
+        'org.freedesktop.DBus.Introspectable': {},
+        'org.freedesktop.DBus.Properties': {},
+        'com.example.Interface1': {'number': DBusUint32(2)},
+        'com.example.Interface2': {'value': DBusString('FOO')},
+      },
+    );
     await client1.registerObject(object2);
 
     // Subscribe to object manager signals.
-    var remoteManagerObject = DBusRemoteObjectManager(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
-    remoteManagerObject.signals.listen(expectAsync1((signal) {
-      expect(signal, TypeMatcher<DBusObjectManagerInterfacesRemovedSignal>());
-      var interfacesRemoved =
-          signal as DBusObjectManagerInterfacesRemovedSignal;
-      expect(interfacesRemoved.changedPath,
-          equals(DBusObjectPath('/com/example/Object2')));
-      expect(
+    var remoteManagerObject = DBusRemoteObjectManager(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
+    remoteManagerObject.signals.listen(
+      expectAsync1((signal) {
+        expect(signal, TypeMatcher<DBusObjectManagerInterfacesRemovedSignal>());
+        var interfacesRemoved =
+            signal as DBusObjectManagerInterfacesRemovedSignal;
+        expect(
+          interfacesRemoved.changedPath,
+          equals(DBusObjectPath('/com/example/Object2')),
+        );
+        expect(
           interfacesRemoved.interfaces,
           equals([
             'org.freedesktop.DBus.Introspectable',
             'org.freedesktop.DBus.Properties',
             'com.example.Interface1',
-            'com.example.Interface2'
-          ]));
-    }));
+            'com.example.Interface2',
+          ]),
+        );
+      }),
+    );
 
     // Do a round-trip to the server to ensure the signal has been subscribed to.
     await client2.ping();
@@ -4766,19 +5852,21 @@ void main() {
     // Check object is removed.
     var objects = await remoteManagerObject.getManagedObjects();
     expect(
-        objects,
-        equals({
-          DBusObjectPath('/com/example/Object1'): {
-            'org.freedesktop.DBus.Introspectable': {},
-            'org.freedesktop.DBus.Properties': {}
-          }
-        }));
+      objects,
+      equals({
+        DBusObjectPath('/com/example/Object1'): {
+          'org.freedesktop.DBus.Introspectable': {},
+          'org.freedesktop.DBus.Properties': {},
+        },
+      }),
+    );
   });
 
   test('object manager - interface added', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4791,27 +5879,36 @@ void main() {
     var objectManager = DBusObject(DBusObjectPath('/'), isObjectManager: true);
     await client1.registerObject(objectManager);
     var object = TestObject(
-        path: DBusObjectPath('/com/example/Object'),
-        interfacesAndProperties_: {'com.example.Interface1': {}});
+      path: DBusObjectPath('/com/example/Object'),
+      interfacesAndProperties_: {'com.example.Interface1': {}},
+    );
     await client1.registerObject(object);
 
     // Subscribe to object manager signals.
-    var remoteManagerObject = DBusRemoteObjectManager(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
-    remoteManagerObject.signals.listen(expectAsync1((signal) {
-      expect(signal, TypeMatcher<DBusObjectManagerInterfacesAddedSignal>());
-      var interfacesAdded = signal as DBusObjectManagerInterfacesAddedSignal;
-      expect(interfacesAdded.changedPath,
-          equals(DBusObjectPath('/com/example/Object')));
-      expect(
+    var remoteManagerObject = DBusRemoteObjectManager(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
+    remoteManagerObject.signals.listen(
+      expectAsync1((signal) {
+        expect(signal, TypeMatcher<DBusObjectManagerInterfacesAddedSignal>());
+        var interfacesAdded = signal as DBusObjectManagerInterfacesAddedSignal;
+        expect(
+          interfacesAdded.changedPath,
+          equals(DBusObjectPath('/com/example/Object')),
+        );
+        expect(
           interfacesAdded.interfacesAndProperties,
           equals({
             'com.example.Interface2': {
               'Property1': DBusString('VALUE1'),
-              'Property2': DBusString('VALUE2')
-            }
-          }));
-    }));
+              'Property2': DBusString('VALUE2'),
+            },
+          }),
+        );
+      }),
+    );
 
     // Do a round-trip to the server to ensure the signal has been subscribed to.
     await client2.ping();
@@ -4821,15 +5918,16 @@ void main() {
     await objectManager.emitInterfacesAdded(object.path, {
       'com.example.Interface2': {
         'Property1': DBusString('VALUE1'),
-        'Property2': DBusString('VALUE2')
-      }
+        'Property2': DBusString('VALUE2'),
+      },
     });
   });
 
   test('object manager - interface removed', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4842,38 +5940,51 @@ void main() {
     var objectManager = DBusObject(DBusObjectPath('/'), isObjectManager: true);
     await client1.registerObject(objectManager);
     var object = TestObject(
-        path: DBusObjectPath('/com/example/Object'),
-        interfacesAndProperties_: {
-          'com.example.Interface1': {},
-          'com.example.Interface2': {}
-        });
+      path: DBusObjectPath('/com/example/Object'),
+      interfacesAndProperties_: {
+        'com.example.Interface1': {},
+        'com.example.Interface2': {},
+      },
+    );
     await client1.registerObject(object);
 
     // Subscribe to object manager signals.
-    var remoteManagerObject = DBusRemoteObjectManager(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
-    remoteManagerObject.signals.listen(expectAsync1((signal) {
-      expect(signal, TypeMatcher<DBusObjectManagerInterfacesRemovedSignal>());
-      var interfacesRemoved =
-          signal as DBusObjectManagerInterfacesRemovedSignal;
-      expect(interfacesRemoved.changedPath,
-          equals(DBusObjectPath('/com/example/Object')));
-      expect(interfacesRemoved.interfaces, equals(['com.example.Interface2']));
-    }));
+    var remoteManagerObject = DBusRemoteObjectManager(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
+    remoteManagerObject.signals.listen(
+      expectAsync1((signal) {
+        expect(signal, TypeMatcher<DBusObjectManagerInterfacesRemovedSignal>());
+        var interfacesRemoved =
+            signal as DBusObjectManagerInterfacesRemovedSignal;
+        expect(
+          interfacesRemoved.changedPath,
+          equals(DBusObjectPath('/com/example/Object')),
+        );
+        expect(
+          interfacesRemoved.interfaces,
+          equals(['com.example.Interface2']),
+        );
+      }),
+    );
 
     // Do a round-trip to the server to ensure the signal has been subscribed to.
     await client2.ping();
 
     // Remove an interface from the object.
     object.removeInterface('com.example.Interface2');
-    await objectManager
-        .emitInterfacesRemoved(object.path, ['com.example.Interface2']);
+    await objectManager.emitInterfacesRemoved(object.path, [
+      'com.example.Interface2',
+    ]);
   });
 
   test('object manager - properties changed', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4886,42 +5997,53 @@ void main() {
     var objectManager = DBusObject(DBusObjectPath('/'), isObjectManager: true);
     await client1.registerObject(objectManager);
     var object = TestObject(
-        path: DBusObjectPath('/com/example/Object'),
-        interfacesAndProperties_: {
-          'com.example.Interface1': {},
-          'com.example.Interface2': {}
-        });
+      path: DBusObjectPath('/com/example/Object'),
+      interfacesAndProperties_: {
+        'com.example.Interface1': {},
+        'com.example.Interface2': {},
+      },
+    );
     await client1.registerObject(object);
 
     // Subscribe to object manager signals.
-    var remoteManagerObject = DBusRemoteObjectManager(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
-    remoteManagerObject.signals.listen(expectAsync1((signal) {
-      expect(signal, TypeMatcher<DBusPropertiesChangedSignal>());
-      var propertiesChanged = signal as DBusPropertiesChangedSignal;
-      expect(
+    var remoteManagerObject = DBusRemoteObjectManager(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
+    remoteManagerObject.signals.listen(
+      expectAsync1((signal) {
+        expect(signal, TypeMatcher<DBusPropertiesChangedSignal>());
+        var propertiesChanged = signal as DBusPropertiesChangedSignal;
+        expect(
           propertiesChanged.changedProperties,
           equals({
             'Property1': DBusString('VALUE1'),
-            'Property2': DBusString('VALUE2')
-          }));
-      expect(propertiesChanged.invalidatedProperties, equals([]));
-    }));
+            'Property2': DBusString('VALUE2'),
+          }),
+        );
+        expect(propertiesChanged.invalidatedProperties, equals([]));
+      }),
+    );
 
     // Do a round-trip to the server to ensure the signal has been subscribed to.
     await client2.ping();
 
     // Change a property on the object.
-    await object.emitPropertiesChanged('com.example.Test', changedProperties: {
-      'Property1': DBusString('VALUE1'),
-      'Property2': DBusString('VALUE2')
-    });
+    await object.emitPropertiesChanged(
+      'com.example.Test',
+      changedProperties: {
+        'Property1': DBusString('VALUE1'),
+        'Property2': DBusString('VALUE2'),
+      },
+    );
   });
 
   test('object manager - object added from method call', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4936,27 +6058,38 @@ void main() {
     // Subscribe to object manager signals.
     // Check that the signal is recived before the method call response completes.
     var methodCallDone = false;
-    var remoteManagerObject = DBusRemoteObjectManager(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
-    remoteManagerObject.signals.listen(expectAsync1((signal) {
-      expect(methodCallDone, isFalse);
-      expect(signal, TypeMatcher<DBusObjectManagerInterfacesAddedSignal>());
-      var interfacesAdded = signal as DBusObjectManagerInterfacesAddedSignal;
-      expect(interfacesAdded.changedPath,
-          equals(DBusObjectPath('/com/example/Object1')));
-    }));
+    var remoteManagerObject = DBusRemoteObjectManager(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
+    remoteManagerObject.signals.listen(
+      expectAsync1((signal) {
+        expect(methodCallDone, isFalse);
+        expect(signal, TypeMatcher<DBusObjectManagerInterfacesAddedSignal>());
+        var interfacesAdded = signal as DBusObjectManagerInterfacesAddedSignal;
+        expect(
+          interfacesAdded.changedPath,
+          equals(DBusObjectPath('/com/example/Object1')),
+        );
+      }),
+    );
 
     // Call a method that adds an object.
-    var remoteObject = DBusRemoteObject(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
+    var remoteObject = DBusRemoteObject(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
     await remoteObject.callMethod('com.example.Test', 'AddObject', []);
     methodCallDone = true;
   });
 
   test('object manager - empty object', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -4968,26 +6101,32 @@ void main() {
     // Register an object manager and an empty object.
     var objectManager = DBusObject(DBusObjectPath('/'), isObjectManager: true);
     await client1.registerObject(objectManager);
-    await client1
-        .registerObject(DBusObject(DBusObjectPath('/com/example/Object1')));
+    await client1.registerObject(
+      DBusObject(DBusObjectPath('/com/example/Object1')),
+    );
 
-    var remoteManagerObject = DBusRemoteObjectManager(client2,
-        name: client1.uniqueName, path: DBusObjectPath('/'));
+    var remoteManagerObject = DBusRemoteObjectManager(
+      client2,
+      name: client1.uniqueName,
+      path: DBusObjectPath('/'),
+    );
     var objects = await remoteManagerObject.getManagedObjects();
     expect(
-        objects,
-        equals({
-          DBusObjectPath('/com/example/Object1'): {
-            'org.freedesktop.DBus.Introspectable': {},
-            'org.freedesktop.DBus.Properties': {}
-          }
-        }));
+      objects,
+      equals({
+        DBusObjectPath('/com/example/Object1'): {
+          'org.freedesktop.DBus.Introspectable': {},
+          'org.freedesktop.DBus.Properties': {},
+        },
+      }),
+    );
   });
 
   test('object manager - unknown method', () async {
     var server = DBusServer();
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client1 = DBusClient(address);
     var client2 = DBusClient(address);
     addTearDown(() async {
@@ -5002,18 +6141,21 @@ void main() {
 
     // Try and access an unknown method on the object manager interface.
     expect(
-        () => client2.callMethod(
-            destination: client1.uniqueName,
-            path: DBusObjectPath('/'),
-            interface: 'org.freedesktop.DBus.ObjectManager',
-            name: 'NoSuchMethod'),
-        throwsA(isA<DBusUnknownMethodException>()));
+      () => client2.callMethod(
+        destination: client1.uniqueName,
+        path: DBusObjectPath('/'),
+        interface: 'org.freedesktop.DBus.ObjectManager',
+        name: 'NoSuchMethod',
+      ),
+      throwsA(isA<DBusUnknownMethodException>()),
+    );
   });
 
   test('no message bus', () async {
     var server = DBusServer(messageBus: false);
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address, messageBus: false);
     addTearDown(() async {
       await client.close();
@@ -5025,8 +6167,9 @@ void main() {
 
   test('no message bus - introspect', () async {
     var server = DBusServer(messageBus: false);
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address, messageBus: false);
     addTearDown(() async {
       await client.close();
@@ -5034,40 +6177,50 @@ void main() {
     });
 
     // Read introspection data from the server.
-    var remoteObject = DBusRemoteObject(client,
-        name: 'org.freedesktop.DBus', path: DBusObjectPath('/'));
+    var remoteObject = DBusRemoteObject(
+      client,
+      name: 'org.freedesktop.DBus',
+      path: DBusObjectPath('/'),
+    );
     var node = await remoteObject.introspect();
     expect(node.toXml().toXmlString(), equals('<node/>'));
   });
 
   test('no message bus - subscribe signal', () async {
     var server = DBusServer(messageBus: false);
-    var address =
-        await server.listenAddress(DBusAddress.unix(dir: Directory.systemTemp));
+    var address = await server.listenAddress(
+      DBusAddress.unix(dir: Directory.systemTemp),
+    );
     var client = DBusClient(address, messageBus: false);
     addTearDown(() async {
       await client.close();
       await server.close();
     });
 
-    var signals =
-        DBusSignalStream(client, interface: 'com.example.Test', name: 'Ping');
-    signals.listen(expectAsync1((signal) {
-      expect(signal.sender, isNull);
-      expect(signal.path, equals(DBusObjectPath('/')));
-      expect(signal.interface, equals('com.example.Test'));
-      expect(signal.name, equals('Ping'));
-      expect(signal.values, equals([DBusString('Hello'), DBusUint32(42)]));
-    }));
+    var signals = DBusSignalStream(
+      client,
+      interface: 'com.example.Test',
+      name: 'Ping',
+    );
+    signals.listen(
+      expectAsync1((signal) {
+        expect(signal.sender, isNull);
+        expect(signal.path, equals(DBusObjectPath('/')));
+        expect(signal.interface, equals('com.example.Test'));
+        expect(signal.name, equals('Ping'));
+        expect(signal.values, equals([DBusString('Hello'), DBusUint32(42)]));
+      }),
+    );
 
     // Ensure client is connected.
     await client.ping();
 
     server.emitSignal(
-        path: DBusObjectPath('/'),
-        interface: 'com.example.Test',
-        name: 'Ping',
-        values: [DBusString('Hello'), DBusUint32(42)]);
+      path: DBusObjectPath('/'),
+      interface: 'com.example.Test',
+      name: 'Ping',
+      values: [DBusString('Hello'), DBusUint32(42)],
+    );
   });
 
   test('introspect xml - empty', () {
@@ -5090,613 +6243,989 @@ void main() {
 
   test('introspect xml - interface annotation', () {
     var node = parseDBusIntrospectXml(
-        '<node><interface name="com.example.Test"><annotation name="com.example.Test.Name" value="AnnotationValue"/></interface></node>');
+      '<node><interface name="com.example.Test"><annotation name="com.example.Test.Name" value="AnnotationValue"/></interface></node>',
+    );
     expect(
-        node,
-        equals(DBusIntrospectNode(interfaces: [
-          DBusIntrospectInterface('com.example.Test', annotations: [
-            DBusIntrospectAnnotation('com.example.Test.Name', 'AnnotationValue')
-          ])
-        ])));
+      node,
+      equals(
+        DBusIntrospectNode(
+          interfaces: [
+            DBusIntrospectInterface(
+              'com.example.Test',
+              annotations: [
+                DBusIntrospectAnnotation(
+                  'com.example.Test.Name',
+                  'AnnotationValue',
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
   });
 
   test('introspect xml - empty interface', () {
     var node = parseDBusIntrospectXml(
-        '<node><interface name="com.example.Test"/></node>');
+      '<node><interface name="com.example.Test"/></node>',
+    );
     expect(
-        node,
-        equals(DBusIntrospectNode(
-            interfaces: [DBusIntrospectInterface('com.example.Test')])));
+      node,
+      equals(
+        DBusIntrospectNode(
+          interfaces: [DBusIntrospectInterface('com.example.Test')],
+        ),
+      ),
+    );
   });
 
   test('introspect xml - missing interface name', () {
-    expect(() => parseDBusIntrospectXml('<node><interface/></node>'),
-        throwsFormatException);
+    expect(
+      () => parseDBusIntrospectXml('<node><interface/></node>'),
+      throwsFormatException,
+    );
   });
 
   test('introspect xml - method no args', () {
     var node = parseDBusIntrospectXml(
-        '<node><interface name="com.example.Test"><method name="Hello"/></interface></node>');
+      '<node><interface name="com.example.Test"><method name="Hello"/></interface></node>',
+    );
     expect(
-        node,
-        equals(DBusIntrospectNode(interfaces: [
-          DBusIntrospectInterface('com.example.Test',
-              methods: [DBusIntrospectMethod('Hello')])
-        ])));
+      node,
+      equals(
+        DBusIntrospectNode(
+          interfaces: [
+            DBusIntrospectInterface(
+              'com.example.Test',
+              methods: [DBusIntrospectMethod('Hello')],
+            ),
+          ],
+        ),
+      ),
+    );
   });
 
   test('introspect xml - method input arg', () {
     var node = parseDBusIntrospectXml(
-        '<node><interface name="com.example.Test"><method name="Hello"><arg type="s"/></method></interface></node>');
+      '<node><interface name="com.example.Test"><method name="Hello"><arg type="s"/></method></interface></node>',
+    );
     expect(
-        node,
-        equals(DBusIntrospectNode(interfaces: [
-          DBusIntrospectInterface('com.example.Test', methods: [
-            DBusIntrospectMethod('Hello', args: [
-              DBusIntrospectArgument(
-                  DBusSignature('s'), DBusArgumentDirection.in_)
-            ])
-          ])
-        ])));
+      node,
+      equals(
+        DBusIntrospectNode(
+          interfaces: [
+            DBusIntrospectInterface(
+              'com.example.Test',
+              methods: [
+                DBusIntrospectMethod(
+                  'Hello',
+                  args: [
+                    DBusIntrospectArgument(
+                      DBusSignature('s'),
+                      DBusArgumentDirection.in_,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
   });
 
   test('introspect xml - method named arg', () {
     var node = parseDBusIntrospectXml(
-        '<node><interface name="com.example.Test"><method name="Hello"><arg name="text" type="s"/></method></interface></node>');
+      '<node><interface name="com.example.Test"><method name="Hello"><arg name="text" type="s"/></method></interface></node>',
+    );
     expect(
-        node,
-        equals(DBusIntrospectNode(interfaces: [
-          DBusIntrospectInterface('com.example.Test', methods: [
-            DBusIntrospectMethod('Hello', args: [
-              DBusIntrospectArgument(
-                  DBusSignature('s'), DBusArgumentDirection.in_,
-                  name: 'text')
-            ])
-          ])
-        ])));
+      node,
+      equals(
+        DBusIntrospectNode(
+          interfaces: [
+            DBusIntrospectInterface(
+              'com.example.Test',
+              methods: [
+                DBusIntrospectMethod(
+                  'Hello',
+                  args: [
+                    DBusIntrospectArgument(
+                      DBusSignature('s'),
+                      DBusArgumentDirection.in_,
+                      name: 'text',
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
   });
 
   test('introspect xml - method input arg', () {
     var node = parseDBusIntrospectXml(
-        '<node><interface name="com.example.Test"><method name="Hello"><arg type="s" direction="in"/></method></interface></node>');
+      '<node><interface name="com.example.Test"><method name="Hello"><arg type="s" direction="in"/></method></interface></node>',
+    );
     expect(
-        node,
-        equals(DBusIntrospectNode(interfaces: [
-          DBusIntrospectInterface('com.example.Test', methods: [
-            DBusIntrospectMethod('Hello', args: [
-              DBusIntrospectArgument(
-                  DBusSignature('s'), DBusArgumentDirection.in_)
-            ])
-          ])
-        ])));
+      node,
+      equals(
+        DBusIntrospectNode(
+          interfaces: [
+            DBusIntrospectInterface(
+              'com.example.Test',
+              methods: [
+                DBusIntrospectMethod(
+                  'Hello',
+                  args: [
+                    DBusIntrospectArgument(
+                      DBusSignature('s'),
+                      DBusArgumentDirection.in_,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
   });
 
   test('introspect xml - method output arg', () {
     var node = parseDBusIntrospectXml(
-        '<node><interface name="com.example.Test"><method name="Hello"><arg type="s" direction="out"/></method></interface></node>');
+      '<node><interface name="com.example.Test"><method name="Hello"><arg type="s" direction="out"/></method></interface></node>',
+    );
     expect(
-        node,
-        equals(DBusIntrospectNode(interfaces: [
-          DBusIntrospectInterface('com.example.Test', methods: [
-            DBusIntrospectMethod('Hello', args: [
-              DBusIntrospectArgument(
-                  DBusSignature('s'), DBusArgumentDirection.out)
-            ])
-          ])
-        ])));
+      node,
+      equals(
+        DBusIntrospectNode(
+          interfaces: [
+            DBusIntrospectInterface(
+              'com.example.Test',
+              methods: [
+                DBusIntrospectMethod(
+                  'Hello',
+                  args: [
+                    DBusIntrospectArgument(
+                      DBusSignature('s'),
+                      DBusArgumentDirection.out,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
   });
 
   test('introspect xml - method arg annotation', () {
     var node = parseDBusIntrospectXml(
-        '<node><interface name="com.example.Test"><method name="Hello"><arg type="s"><annotation name="com.example.Test.Name" value="AnnotationValue"/></arg></method></interface></node>');
+      '<node><interface name="com.example.Test"><method name="Hello"><arg type="s"><annotation name="com.example.Test.Name" value="AnnotationValue"/></arg></method></interface></node>',
+    );
     expect(
-        node,
-        equals(DBusIntrospectNode(interfaces: [
-          DBusIntrospectInterface('com.example.Test', methods: [
-            DBusIntrospectMethod('Hello', args: [
-              DBusIntrospectArgument(
-                  DBusSignature('s'), DBusArgumentDirection.in_, annotations: [
-                DBusIntrospectAnnotation(
-                    'com.example.Test.Name', 'AnnotationValue')
-              ])
-            ])
-          ])
-        ])));
+      node,
+      equals(
+        DBusIntrospectNode(
+          interfaces: [
+            DBusIntrospectInterface(
+              'com.example.Test',
+              methods: [
+                DBusIntrospectMethod(
+                  'Hello',
+                  args: [
+                    DBusIntrospectArgument(
+                      DBusSignature('s'),
+                      DBusArgumentDirection.in_,
+                      annotations: [
+                        DBusIntrospectAnnotation(
+                          'com.example.Test.Name',
+                          'AnnotationValue',
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
   });
 
   test('introspect xml - method annotation', () {
     var node = parseDBusIntrospectXml(
-        '<node><interface name="com.example.Test"><method name="Hello"><annotation name="com.example.Test.Name" value="AnnotationValue"/></method></interface></node>');
+      '<node><interface name="com.example.Test"><method name="Hello"><annotation name="com.example.Test.Name" value="AnnotationValue"/></method></interface></node>',
+    );
     expect(
-        node,
-        equals(DBusIntrospectNode(interfaces: [
-          DBusIntrospectInterface('com.example.Test', methods: [
-            DBusIntrospectMethod('Hello', annotations: [
-              DBusIntrospectAnnotation(
-                  'com.example.Test.Name', 'AnnotationValue')
-            ])
-          ])
-        ])));
+      node,
+      equals(
+        DBusIntrospectNode(
+          interfaces: [
+            DBusIntrospectInterface(
+              'com.example.Test',
+              methods: [
+                DBusIntrospectMethod(
+                  'Hello',
+                  annotations: [
+                    DBusIntrospectAnnotation(
+                      'com.example.Test.Name',
+                      'AnnotationValue',
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
   });
 
   test('introspect xml - missing method name', () {
     expect(
-        () => parseDBusIntrospectXml(
-            '<node><interface name="com.example.Test"><method/></interface></node>'),
-        throwsFormatException);
+      () => parseDBusIntrospectXml(
+        '<node><interface name="com.example.Test"><method/></interface></node>',
+      ),
+      throwsFormatException,
+    );
   });
 
   test('introspect xml - missing argument type', () {
     expect(
-        () => parseDBusIntrospectXml(
-            '<node><interface name="com.example.Test"><method name="Hello"><arg/></method></interface></node>'),
-        throwsFormatException);
+      () => parseDBusIntrospectXml(
+        '<node><interface name="com.example.Test"><method name="Hello"><arg/></method></interface></node>',
+      ),
+      throwsFormatException,
+    );
   });
 
   test('introspect xml - unknown argument direction', () {
     expect(
-        () => parseDBusIntrospectXml(
-            '<node><interface name="com.example.Test"><method name="Hello"><arg type="s" direction="down"/></method></interface></node>'),
-        throwsFormatException);
+      () => parseDBusIntrospectXml(
+        '<node><interface name="com.example.Test"><method name="Hello"><arg type="s" direction="down"/></method></interface></node>',
+      ),
+      throwsFormatException,
+    );
   });
 
   test('introspect xml - signal', () {
     var node = parseDBusIntrospectXml(
-        '<node><interface name="com.example.Test"><signal name="CountChanged"/></interface></node>');
+      '<node><interface name="com.example.Test"><signal name="CountChanged"/></interface></node>',
+    );
     expect(
-        node,
-        equals(DBusIntrospectNode(interfaces: [
-          DBusIntrospectInterface('com.example.Test',
-              signals: [DBusIntrospectSignal('CountChanged')])
-        ])));
+      node,
+      equals(
+        DBusIntrospectNode(
+          interfaces: [
+            DBusIntrospectInterface(
+              'com.example.Test',
+              signals: [DBusIntrospectSignal('CountChanged')],
+            ),
+          ],
+        ),
+      ),
+    );
 
-    expect(DBusIntrospectSignal('Signal1').toString(),
-        equals("DBusIntrospectSignal('Signal1')"));
+    expect(
+      DBusIntrospectSignal('Signal1').toString(),
+      equals("DBusIntrospectSignal('Signal1')"),
+    );
   });
 
   test('introspect xml - signal argument', () {
     var node = parseDBusIntrospectXml(
-        '<node><interface name="com.example.Test"><signal name="CountChanged"><arg type="u"/></signal></interface></node>');
+      '<node><interface name="com.example.Test"><signal name="CountChanged"><arg type="u"/></signal></interface></node>',
+    );
     expect(
-        node,
-        equals(DBusIntrospectNode(interfaces: [
-          DBusIntrospectInterface('com.example.Test', signals: [
-            DBusIntrospectSignal('CountChanged', args: [
-              DBusIntrospectArgument(
-                  DBusSignature('u'), DBusArgumentDirection.out)
-            ])
-          ])
-        ])));
+      node,
+      equals(
+        DBusIntrospectNode(
+          interfaces: [
+            DBusIntrospectInterface(
+              'com.example.Test',
+              signals: [
+                DBusIntrospectSignal(
+                  'CountChanged',
+                  args: [
+                    DBusIntrospectArgument(
+                      DBusSignature('u'),
+                      DBusArgumentDirection.out,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
   });
 
   test('introspect xml - signal output argument', () {
     var node = parseDBusIntrospectXml(
-        '<node><interface name="com.example.Test"><signal name="CountChanged"><arg type="u" direction="out"/></signal></interface></node>');
+      '<node><interface name="com.example.Test"><signal name="CountChanged"><arg type="u" direction="out"/></signal></interface></node>',
+    );
     expect(
-        node,
-        equals(DBusIntrospectNode(interfaces: [
-          DBusIntrospectInterface('com.example.Test', signals: [
-            DBusIntrospectSignal('CountChanged', args: [
-              DBusIntrospectArgument(
-                  DBusSignature('u'), DBusArgumentDirection.out)
-            ])
-          ])
-        ])));
+      node,
+      equals(
+        DBusIntrospectNode(
+          interfaces: [
+            DBusIntrospectInterface(
+              'com.example.Test',
+              signals: [
+                DBusIntrospectSignal(
+                  'CountChanged',
+                  args: [
+                    DBusIntrospectArgument(
+                      DBusSignature('u'),
+                      DBusArgumentDirection.out,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
   });
 
   test('introspect xml - signal annotation', () {
     var node = parseDBusIntrospectXml(
-        '<node><interface name="com.example.Test"><signal name="CountChanged"><annotation name="com.example.Test.Name" value="AnnotationValue"/></signal></interface></node>');
+      '<node><interface name="com.example.Test"><signal name="CountChanged"><annotation name="com.example.Test.Name" value="AnnotationValue"/></signal></interface></node>',
+    );
     expect(
-        node,
-        equals(DBusIntrospectNode(interfaces: [
-          DBusIntrospectInterface('com.example.Test', signals: [
-            DBusIntrospectSignal('CountChanged', annotations: [
-              DBusIntrospectAnnotation(
-                  'com.example.Test.Name', 'AnnotationValue')
-            ])
-          ])
-        ])));
+      node,
+      equals(
+        DBusIntrospectNode(
+          interfaces: [
+            DBusIntrospectInterface(
+              'com.example.Test',
+              signals: [
+                DBusIntrospectSignal(
+                  'CountChanged',
+                  annotations: [
+                    DBusIntrospectAnnotation(
+                      'com.example.Test.Name',
+                      'AnnotationValue',
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
   });
 
   test('introspect xml - signal no name', () {
     expect(
-        () => parseDBusIntrospectXml(
-            '<node><interface name="com.example.Test"><signal/></interface></node>'),
-        throwsFormatException);
+      () => parseDBusIntrospectXml(
+        '<node><interface name="com.example.Test"><signal/></interface></node>',
+      ),
+      throwsFormatException,
+    );
   });
 
   test('introspect xml - signal input argument', () {
     expect(
-        () => parseDBusIntrospectXml(
-            '<node><interface name="com.example.Test"><signal><arg type="u" direction="in"/></signal></interface></node>'),
-        throwsFormatException);
+      () => parseDBusIntrospectXml(
+        '<node><interface name="com.example.Test"><signal><arg type="u" direction="in"/></signal></interface></node>',
+      ),
+      throwsFormatException,
+    );
   });
 
   test('introspect xml - property', () {
     var node = parseDBusIntrospectXml(
-        '<node><interface name="com.example.Test"><property name="Count" type="u"/></interface></node>');
+      '<node><interface name="com.example.Test"><property name="Count" type="u"/></interface></node>',
+    );
     expect(
-        node,
-        equals(DBusIntrospectNode(interfaces: [
-          DBusIntrospectInterface('com.example.Test',
-              properties: [DBusIntrospectProperty('Count', DBusSignature('u'))])
-        ])));
+      node,
+      equals(
+        DBusIntrospectNode(
+          interfaces: [
+            DBusIntrospectInterface(
+              'com.example.Test',
+              properties: [DBusIntrospectProperty('Count', DBusSignature('u'))],
+            ),
+          ],
+        ),
+      ),
+    );
 
-    expect(DBusIntrospectProperty('Property1', DBusSignature('s')).toString(),
-        equals("DBusIntrospectProperty('Property1', DBusSignature('s'))"));
+    expect(
+      DBusIntrospectProperty('Property1', DBusSignature('s')).toString(),
+      equals("DBusIntrospectProperty('Property1', DBusSignature('s'))"),
+    );
   });
 
   test('introspect xml - property - read access', () {
     var node = parseDBusIntrospectXml(
-        '<node><interface name="com.example.Test"><property name="Count" type="u" access="read"/></interface></node>');
+      '<node><interface name="com.example.Test"><property name="Count" type="u" access="read"/></interface></node>',
+    );
     expect(
-        node,
-        equals(DBusIntrospectNode(interfaces: [
-          DBusIntrospectInterface('com.example.Test', properties: [
-            DBusIntrospectProperty('Count', DBusSignature('u'),
-                access: DBusPropertyAccess.read)
-          ])
-        ])));
+      node,
+      equals(
+        DBusIntrospectNode(
+          interfaces: [
+            DBusIntrospectInterface(
+              'com.example.Test',
+              properties: [
+                DBusIntrospectProperty(
+                  'Count',
+                  DBusSignature('u'),
+                  access: DBusPropertyAccess.read,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
   });
 
   test('introspect xml - property - write access', () {
     var node = parseDBusIntrospectXml(
-        '<node><interface name="com.example.Test"><property name="Count" type="u" access="write"/></interface></node>');
+      '<node><interface name="com.example.Test"><property name="Count" type="u" access="write"/></interface></node>',
+    );
     expect(
-        node,
-        equals(DBusIntrospectNode(interfaces: [
-          DBusIntrospectInterface('com.example.Test', properties: [
-            DBusIntrospectProperty('Count', DBusSignature('u'),
-                access: DBusPropertyAccess.write)
-          ])
-        ])));
+      node,
+      equals(
+        DBusIntrospectNode(
+          interfaces: [
+            DBusIntrospectInterface(
+              'com.example.Test',
+              properties: [
+                DBusIntrospectProperty(
+                  'Count',
+                  DBusSignature('u'),
+                  access: DBusPropertyAccess.write,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
   });
 
   test('introspect xml - property - readwrite access', () {
     var node = parseDBusIntrospectXml(
-        '<node><interface name="com.example.Test"><property name="Count" type="u" access="readwrite"/></interface></node>');
+      '<node><interface name="com.example.Test"><property name="Count" type="u" access="readwrite"/></interface></node>',
+    );
     expect(
-        node,
-        equals(DBusIntrospectNode(interfaces: [
-          DBusIntrospectInterface('com.example.Test', properties: [
-            DBusIntrospectProperty('Count', DBusSignature('u'),
-                access: DBusPropertyAccess.readwrite)
-          ])
-        ])));
+      node,
+      equals(
+        DBusIntrospectNode(
+          interfaces: [
+            DBusIntrospectInterface(
+              'com.example.Test',
+              properties: [
+                DBusIntrospectProperty(
+                  'Count',
+                  DBusSignature('u'),
+                  access: DBusPropertyAccess.readwrite,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
   });
 
   test('introspect xml - property annotation', () {
     var node = parseDBusIntrospectXml(
-        '<node><interface name="com.example.Test"><property name="Count" type="u"><annotation name="com.example.Test.Name" value="AnnotationValue"/></property></interface></node>');
+      '<node><interface name="com.example.Test"><property name="Count" type="u"><annotation name="com.example.Test.Name" value="AnnotationValue"/></property></interface></node>',
+    );
     expect(
-        node,
-        equals(DBusIntrospectNode(interfaces: [
-          DBusIntrospectInterface('com.example.Test', properties: [
-            DBusIntrospectProperty('Count', DBusSignature('u'), annotations: [
-              DBusIntrospectAnnotation(
-                  'com.example.Test.Name', 'AnnotationValue')
-            ])
-          ])
-        ])));
+      node,
+      equals(
+        DBusIntrospectNode(
+          interfaces: [
+            DBusIntrospectInterface(
+              'com.example.Test',
+              properties: [
+                DBusIntrospectProperty(
+                  'Count',
+                  DBusSignature('u'),
+                  annotations: [
+                    DBusIntrospectAnnotation(
+                      'com.example.Test.Name',
+                      'AnnotationValue',
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
   });
 
   test('introspect xml - property no name or type', () {
     expect(
-        () => parseDBusIntrospectXml(
-            '<node><interface name="com.example.Test"><property/></interface></node>'),
-        throwsFormatException);
+      () => parseDBusIntrospectXml(
+        '<node><interface name="com.example.Test"><property/></interface></node>',
+      ),
+      throwsFormatException,
+    );
   });
 
   test('introspect xml - property no name', () {
     expect(
-        () => parseDBusIntrospectXml(
-            '<node><interface name="com.example.Test"><property type="u"/></interface></node>'),
-        throwsFormatException);
+      () => parseDBusIntrospectXml(
+        '<node><interface name="com.example.Test"><property type="u"/></interface></node>',
+      ),
+      throwsFormatException,
+    );
   });
 
   test('introspect xml - property no type', () {
     expect(
-        () => parseDBusIntrospectXml(
-            '<node><interface name="com.example.Test"><property name="Count"/></interface></node>'),
-        throwsFormatException);
+      () => parseDBusIntrospectXml(
+        '<node><interface name="com.example.Test"><property name="Count"/></interface></node>',
+      ),
+      throwsFormatException,
+    );
   });
 
   test('introspect xml - property unknown access', () {
     expect(
-        () => parseDBusIntrospectXml(
-            '<node><interface name="com.example.Test"><property name="Count" type="u" access="cook"/></interface></node>'),
-        throwsFormatException);
+      () => parseDBusIntrospectXml(
+        '<node><interface name="com.example.Test"><property name="Count" type="u" access="cook"/></interface></node>',
+      ),
+      throwsFormatException,
+    );
   });
 
   test('introspect xml - node', () {
     var noInterfaceNode = DBusIntrospectNode();
     expect(noInterfaceNode.toXml().toXmlString(), equals('<node/>'));
 
-    var interfaceNode =
-        DBusIntrospectNode(name: '/com/example/Object', interfaces: [
-      DBusIntrospectInterface('com.example.Interface1'),
-      DBusIntrospectInterface('com.example.Interface2')
-    ]);
+    var interfaceNode = DBusIntrospectNode(
+      name: '/com/example/Object',
+      interfaces: [
+        DBusIntrospectInterface('com.example.Interface1'),
+        DBusIntrospectInterface('com.example.Interface2'),
+      ],
+    );
     expect(
-        interfaceNode.toXml().toXmlString(),
-        equals('<node name="/com/example/Object">'
-            '<interface name="com.example.Interface1"/>'
-            '<interface name="com.example.Interface2"/>'
-            '</node>'));
+      interfaceNode.toXml().toXmlString(),
+      equals(
+        '<node name="/com/example/Object">'
+        '<interface name="com.example.Interface1"/>'
+        '<interface name="com.example.Interface2"/>'
+        '</node>',
+      ),
+    );
 
-    var treeNode = DBusIntrospectNode(name: '/com/example/Object', interfaces: [
-      DBusIntrospectInterface('com.example.Interface1')
-    ], children: [
-      DBusIntrospectNode(name: 'Subobject1'),
-      DBusIntrospectNode(name: 'Subobject2')
-    ]);
+    var treeNode = DBusIntrospectNode(
+      name: '/com/example/Object',
+      interfaces: [DBusIntrospectInterface('com.example.Interface1')],
+      children: [
+        DBusIntrospectNode(name: 'Subobject1'),
+        DBusIntrospectNode(name: 'Subobject2'),
+      ],
+    );
     expect(
-        treeNode.toXml().toXmlString(),
-        equals('<node name="/com/example/Object">'
-            '<interface name="com.example.Interface1"/>'
-            '<node name="Subobject1"/>'
-            '<node name="Subobject2"/>'
-            '</node>'));
+      treeNode.toXml().toXmlString(),
+      equals(
+        '<node name="/com/example/Object">'
+        '<interface name="com.example.Interface1"/>'
+        '<node name="Subobject1"/>'
+        '<node name="Subobject2"/>'
+        '</node>',
+      ),
+    );
 
     expect(DBusIntrospectNode().toString(), equals('DBusIntrospectNode()'));
   });
 
   test('introspect xml - interface', () {
     var emptyInterface = DBusIntrospectInterface('com.example.Interface1');
-    expect(emptyInterface.toXml().toXmlString(),
-        equals('<interface name="com.example.Interface1"/>'));
-
-    var methodInterface = DBusIntrospectInterface('com.example.Interface1',
-        methods: [
-          DBusIntrospectMethod('Method1'),
-          DBusIntrospectMethod('Method2')
-        ]);
     expect(
-        methodInterface.toXml().toXmlString(),
-        equals('<interface name="com.example.Interface1">'
-            '<method name="Method1"/>'
-            '<method name="Method2"/>'
-            '</interface>'));
+      emptyInterface.toXml().toXmlString(),
+      equals('<interface name="com.example.Interface1"/>'),
+    );
 
-    var signalInterface = DBusIntrospectInterface('com.example.Interface1',
-        signals: [
-          DBusIntrospectSignal('Signal1'),
-          DBusIntrospectSignal('Signal2')
-        ]);
+    var methodInterface = DBusIntrospectInterface(
+      'com.example.Interface1',
+      methods: [
+        DBusIntrospectMethod('Method1'),
+        DBusIntrospectMethod('Method2'),
+      ],
+    );
     expect(
-        signalInterface.toXml().toXmlString(),
-        equals('<interface name="com.example.Interface1">'
-            '<signal name="Signal1"/>'
-            '<signal name="Signal2"/>'
-            '</interface>'));
+      methodInterface.toXml().toXmlString(),
+      equals(
+        '<interface name="com.example.Interface1">'
+        '<method name="Method1"/>'
+        '<method name="Method2"/>'
+        '</interface>',
+      ),
+    );
 
-    var propertyInterface =
-        DBusIntrospectInterface('com.example.Interface1', properties: [
-      DBusIntrospectProperty('Property1', DBusSignature('s')),
-      DBusIntrospectProperty('Property2', DBusSignature('i'))
-    ]);
+    var signalInterface = DBusIntrospectInterface(
+      'com.example.Interface1',
+      signals: [
+        DBusIntrospectSignal('Signal1'),
+        DBusIntrospectSignal('Signal2'),
+      ],
+    );
     expect(
-        propertyInterface.toXml().toXmlString(),
-        equals('<interface name="com.example.Interface1">'
-            '<property name="Property1" type="s" access="readwrite"/>'
-            '<property name="Property2" type="i" access="readwrite"/>'
-            '</interface>'));
+      signalInterface.toXml().toXmlString(),
+      equals(
+        '<interface name="com.example.Interface1">'
+        '<signal name="Signal1"/>'
+        '<signal name="Signal2"/>'
+        '</interface>',
+      ),
+    );
 
-    var annotatedInterface =
-        DBusIntrospectInterface('com.example.Interface1', methods: [
-      DBusIntrospectMethod('Method1')
-    ], signals: [
-      DBusIntrospectSignal('Signal1')
-    ], properties: [
-      DBusIntrospectProperty('Property1', DBusSignature('s'))
-    ], annotations: [
-      DBusIntrospectAnnotation('com.example.Annotation1', 'value1'),
-      DBusIntrospectAnnotation('com.example.Annotation2', 'value2')
-    ]);
+    var propertyInterface = DBusIntrospectInterface(
+      'com.example.Interface1',
+      properties: [
+        DBusIntrospectProperty('Property1', DBusSignature('s')),
+        DBusIntrospectProperty('Property2', DBusSignature('i')),
+      ],
+    );
     expect(
-        annotatedInterface.toXml().toXmlString(),
-        equals('<interface name="com.example.Interface1">'
-            '<method name="Method1"/>'
-            '<signal name="Signal1"/>'
-            '<property name="Property1" type="s" access="readwrite"/>'
-            '<annotation name="com.example.Annotation1" value="value1"/>'
-            '<annotation name="com.example.Annotation2" value="value2"/>'
-            '</interface>'));
+      propertyInterface.toXml().toXmlString(),
+      equals(
+        '<interface name="com.example.Interface1">'
+        '<property name="Property1" type="s" access="readwrite"/>'
+        '<property name="Property2" type="i" access="readwrite"/>'
+        '</interface>',
+      ),
+    );
 
-    expect(DBusIntrospectInterface('com.example.Test.Interface1').toString(),
-        equals("DBusIntrospectInterface('com.example.Test.Interface1')"));
+    var annotatedInterface = DBusIntrospectInterface(
+      'com.example.Interface1',
+      methods: [DBusIntrospectMethod('Method1')],
+      signals: [DBusIntrospectSignal('Signal1')],
+      properties: [DBusIntrospectProperty('Property1', DBusSignature('s'))],
+      annotations: [
+        DBusIntrospectAnnotation('com.example.Annotation1', 'value1'),
+        DBusIntrospectAnnotation('com.example.Annotation2', 'value2'),
+      ],
+    );
+    expect(
+      annotatedInterface.toXml().toXmlString(),
+      equals(
+        '<interface name="com.example.Interface1">'
+        '<method name="Method1"/>'
+        '<signal name="Signal1"/>'
+        '<property name="Property1" type="s" access="readwrite"/>'
+        '<annotation name="com.example.Annotation1" value="value1"/>'
+        '<annotation name="com.example.Annotation2" value="value2"/>'
+        '</interface>',
+      ),
+    );
+
+    expect(
+      DBusIntrospectInterface('com.example.Test.Interface1').toString(),
+      equals("DBusIntrospectInterface('com.example.Test.Interface1')"),
+    );
   });
 
   test('introspect xml - method', () {
     var noArgMethod = DBusIntrospectMethod('Method1');
     expect(
-        noArgMethod.toXml().toXmlString(), equals('<method name="Method1"/>'));
+      noArgMethod.toXml().toXmlString(),
+      equals('<method name="Method1"/>'),
+    );
 
-    var argMethod = DBusIntrospectMethod('Method1', args: [
-      DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.in_),
-      DBusIntrospectArgument(DBusSignature('as'), DBusArgumentDirection.in_,
-          name: 'named_arg'),
-      DBusIntrospectArgument(DBusSignature('i'), DBusArgumentDirection.out)
-    ]);
+    var argMethod = DBusIntrospectMethod(
+      'Method1',
+      args: [
+        DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.in_),
+        DBusIntrospectArgument(
+          DBusSignature('as'),
+          DBusArgumentDirection.in_,
+          name: 'named_arg',
+        ),
+        DBusIntrospectArgument(DBusSignature('i'), DBusArgumentDirection.out),
+      ],
+    );
     expect(
-        argMethod.toXml().toXmlString(),
-        equals('<method name="Method1">'
-            '<arg type="s" direction="in"/>'
-            '<arg name="named_arg" type="as" direction="in"/>'
-            '<arg type="i" direction="out"/>'
-            '</method>'));
+      argMethod.toXml().toXmlString(),
+      equals(
+        '<method name="Method1">'
+        '<arg type="s" direction="in"/>'
+        '<arg name="named_arg" type="as" direction="in"/>'
+        '<arg type="i" direction="out"/>'
+        '</method>',
+      ),
+    );
 
-    var annotatedMethod = DBusIntrospectMethod('Method1', args: [
-      DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.in_),
-    ], annotations: [
-      DBusIntrospectAnnotation('com.example.Annotation1', 'value1'),
-      DBusIntrospectAnnotation('com.example.Annotation2', 'value2')
-    ]);
+    var annotatedMethod = DBusIntrospectMethod(
+      'Method1',
+      args: [
+        DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.in_),
+      ],
+      annotations: [
+        DBusIntrospectAnnotation('com.example.Annotation1', 'value1'),
+        DBusIntrospectAnnotation('com.example.Annotation2', 'value2'),
+      ],
+    );
     expect(
-        annotatedMethod.toXml().toXmlString(),
-        equals('<method name="Method1">'
-            '<arg type="s" direction="in"/>'
-            '<annotation name="com.example.Annotation1" value="value1"/>'
-            '<annotation name="com.example.Annotation2" value="value2"/>'
-            '</method>'));
+      annotatedMethod.toXml().toXmlString(),
+      equals(
+        '<method name="Method1">'
+        '<arg type="s" direction="in"/>'
+        '<annotation name="com.example.Annotation1" value="value1"/>'
+        '<annotation name="com.example.Annotation2" value="value2"/>'
+        '</method>',
+      ),
+    );
 
-    expect(DBusIntrospectMethod('Method1').toString(),
-        equals("DBusIntrospectMethod('Method1')"));
+    expect(
+      DBusIntrospectMethod('Method1').toString(),
+      equals("DBusIntrospectMethod('Method1')"),
+    );
   });
 
   test('introspect xml - signal', () {
     var noArgSignal = DBusIntrospectSignal('Signal1');
     expect(
-        noArgSignal.toXml().toXmlString(), equals('<signal name="Signal1"/>'));
+      noArgSignal.toXml().toXmlString(),
+      equals('<signal name="Signal1"/>'),
+    );
 
-    var argSignal = DBusIntrospectSignal('Signal1', args: [
-      DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.out),
-      DBusIntrospectArgument(DBusSignature('i'), DBusArgumentDirection.out,
-          name: 'named_arg')
-    ]);
+    var argSignal = DBusIntrospectSignal(
+      'Signal1',
+      args: [
+        DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.out),
+        DBusIntrospectArgument(
+          DBusSignature('i'),
+          DBusArgumentDirection.out,
+          name: 'named_arg',
+        ),
+      ],
+    );
     expect(
-        argSignal.toXml().toXmlString(),
-        equals('<signal name="Signal1">'
-            '<arg type="s"/>'
-            '<arg name="named_arg" type="i"/>'
-            '</signal>'));
+      argSignal.toXml().toXmlString(),
+      equals(
+        '<signal name="Signal1">'
+        '<arg type="s"/>'
+        '<arg name="named_arg" type="i"/>'
+        '</signal>',
+      ),
+    );
 
-    var annotatedSignal = DBusIntrospectSignal('Signal1', args: [
-      DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.out),
-    ], annotations: [
-      DBusIntrospectAnnotation('com.example.Annotation1', 'value1'),
-      DBusIntrospectAnnotation('com.example.Annotation2', 'value2')
-    ]);
+    var annotatedSignal = DBusIntrospectSignal(
+      'Signal1',
+      args: [
+        DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.out),
+      ],
+      annotations: [
+        DBusIntrospectAnnotation('com.example.Annotation1', 'value1'),
+        DBusIntrospectAnnotation('com.example.Annotation2', 'value2'),
+      ],
+    );
     expect(
-        annotatedSignal.toXml().toXmlString(),
-        equals('<signal name="Signal1">'
-            '<arg type="s"/>'
-            '<annotation name="com.example.Annotation1" value="value1"/>'
-            '<annotation name="com.example.Annotation2" value="value2"/>'
-            '</signal>'));
+      annotatedSignal.toXml().toXmlString(),
+      equals(
+        '<signal name="Signal1">'
+        '<arg type="s"/>'
+        '<annotation name="com.example.Annotation1" value="value1"/>'
+        '<annotation name="com.example.Annotation2" value="value2"/>'
+        '</signal>',
+      ),
+    );
   });
 
   test('introspect xml - property', () {
     var property = DBusIntrospectProperty('Property1', DBusSignature('s'));
-    expect(property.toXml().toXmlString(),
-        equals('<property name="Property1" type="s" access="readwrite"/>'));
+    expect(
+      property.toXml().toXmlString(),
+      equals('<property name="Property1" type="s" access="readwrite"/>'),
+    );
 
     var readProperty = DBusIntrospectProperty(
-        'ReadProperty', DBusSignature('s'),
-        access: DBusPropertyAccess.read);
-    expect(readProperty.toXml().toXmlString(),
-        equals('<property name="ReadProperty" type="s" access="read"/>'));
+      'ReadProperty',
+      DBusSignature('s'),
+      access: DBusPropertyAccess.read,
+    );
+    expect(
+      readProperty.toXml().toXmlString(),
+      equals('<property name="ReadProperty" type="s" access="read"/>'),
+    );
 
     var writeProperty = DBusIntrospectProperty(
-        'WriteProperty', DBusSignature('i'),
-        access: DBusPropertyAccess.write);
-    expect(writeProperty.toXml().toXmlString(),
-        equals('<property name="WriteProperty" type="i" access="write"/>'));
+      'WriteProperty',
+      DBusSignature('i'),
+      access: DBusPropertyAccess.write,
+    );
+    expect(
+      writeProperty.toXml().toXmlString(),
+      equals('<property name="WriteProperty" type="i" access="write"/>'),
+    );
 
     var readWriteProperty = DBusIntrospectProperty(
-        'ReadWriteProperty', DBusSignature('ay'),
-        access: DBusPropertyAccess.readwrite);
+      'ReadWriteProperty',
+      DBusSignature('ay'),
+      access: DBusPropertyAccess.readwrite,
+    );
     expect(
-        readWriteProperty.toXml().toXmlString(),
-        equals(
-            '<property name="ReadWriteProperty" type="ay" access="readwrite"/>'));
+      readWriteProperty.toXml().toXmlString(),
+      equals(
+        '<property name="ReadWriteProperty" type="ay" access="readwrite"/>',
+      ),
+    );
 
     var annotatedProperty = DBusIntrospectProperty(
-        'Property1', DBusSignature('a{sv}'),
-        annotations: [
-          DBusIntrospectAnnotation('com.example.Annotation1', 'value1'),
-          DBusIntrospectAnnotation('com.example.Annotation2', 'value2')
-        ]);
+      'Property1',
+      DBusSignature('a{sv}'),
+      annotations: [
+        DBusIntrospectAnnotation('com.example.Annotation1', 'value1'),
+        DBusIntrospectAnnotation('com.example.Annotation2', 'value2'),
+      ],
+    );
     expect(
-        annotatedProperty.toXml().toXmlString(),
-        equals('<property name="Property1" type="a{sv}" access="readwrite">'
-            '<annotation name="com.example.Annotation1" value="value1"/>'
-            '<annotation name="com.example.Annotation2" value="value2"/>'
-            '</property>'));
+      annotatedProperty.toXml().toXmlString(),
+      equals(
+        '<property name="Property1" type="a{sv}" access="readwrite">'
+        '<annotation name="com.example.Annotation1" value="value1"/>'
+        '<annotation name="com.example.Annotation2" value="value2"/>'
+        '</property>',
+      ),
+    );
   });
 
   test('introspect xml - argument', () {
-    var inArgument =
-        DBusIntrospectArgument(DBusSignature('i'), DBusArgumentDirection.in_);
-    expect(inArgument.toXml().toXmlString(),
-        equals('<arg type="i" direction="in"/>'));
+    var inArgument = DBusIntrospectArgument(
+      DBusSignature('i'),
+      DBusArgumentDirection.in_,
+    );
+    expect(
+      inArgument.toXml().toXmlString(),
+      equals('<arg type="i" direction="in"/>'),
+    );
 
-    var outArgument =
-        DBusIntrospectArgument(DBusSignature('s'), DBusArgumentDirection.out);
-    expect(outArgument.toXml().toXmlString(),
-        equals('<arg type="s" direction="out"/>'));
+    var outArgument = DBusIntrospectArgument(
+      DBusSignature('s'),
+      DBusArgumentDirection.out,
+    );
+    expect(
+      outArgument.toXml().toXmlString(),
+      equals('<arg type="s" direction="out"/>'),
+    );
 
     var namedArgument = DBusIntrospectArgument(
-        DBusSignature('s'), DBusArgumentDirection.in_,
-        name: 'named_arg');
-    expect(namedArgument.toXml().toXmlString(),
-        equals('<arg name="named_arg" type="s" direction="in"/>'));
+      DBusSignature('s'),
+      DBusArgumentDirection.in_,
+      name: 'named_arg',
+    );
+    expect(
+      namedArgument.toXml().toXmlString(),
+      equals('<arg name="named_arg" type="s" direction="in"/>'),
+    );
 
     var annotatedArgument = DBusIntrospectArgument(
-        DBusSignature('s'), DBusArgumentDirection.out,
-        annotations: [
-          DBusIntrospectAnnotation('com.example.Annotation1', 'value1'),
-          DBusIntrospectAnnotation('com.example.Annotation2', 'value2')
-        ]);
+      DBusSignature('s'),
+      DBusArgumentDirection.out,
+      annotations: [
+        DBusIntrospectAnnotation('com.example.Annotation1', 'value1'),
+        DBusIntrospectAnnotation('com.example.Annotation2', 'value2'),
+      ],
+    );
     expect(
-        annotatedArgument.toXml().toXmlString(),
-        equals('<arg type="s" direction="out">'
-            '<annotation name="com.example.Annotation1" value="value1"/>'
-            '<annotation name="com.example.Annotation2" value="value2"/>'
-            '</arg>'));
+      annotatedArgument.toXml().toXmlString(),
+      equals(
+        '<arg type="s" direction="out">'
+        '<annotation name="com.example.Annotation1" value="value1"/>'
+        '<annotation name="com.example.Annotation2" value="value2"/>'
+        '</arg>',
+      ),
+    );
 
     expect(
-        DBusIntrospectArgument(DBusSignature('u'), DBusArgumentDirection.out)
-            .toString(),
-        equals(
-            "DBusIntrospectArgument(DBusSignature('u'), DBusArgumentDirection.out)"));
+      DBusIntrospectArgument(
+        DBusSignature('u'),
+        DBusArgumentDirection.out,
+      ).toString(),
+      equals(
+        "DBusIntrospectArgument(DBusSignature('u'), DBusArgumentDirection.out)",
+      ),
+    );
   });
 
   test('introspect xml - annotation', () {
-    var annotation =
-        DBusIntrospectAnnotation('com.example.Annotation1', 'value1');
-    expect(annotation.toXml().toXmlString(),
-        equals('<annotation name="com.example.Annotation1" value="value1"/>'));
+    var annotation = DBusIntrospectAnnotation(
+      'com.example.Annotation1',
+      'value1',
+    );
+    expect(
+      annotation.toXml().toXmlString(),
+      equals('<annotation name="com.example.Annotation1" value="value1"/>'),
+    );
 
     expect(
-        DBusIntrospectAnnotation('com.example.Annotation1', 'AnnotationValue')
-            .toString(),
-        equals(
-            "DBusIntrospectAnnotation('com.example.Annotation1', 'AnnotationValue')"));
+      DBusIntrospectAnnotation(
+        'com.example.Annotation1',
+        'AnnotationValue',
+      ).toString(),
+      equals(
+        "DBusIntrospectAnnotation('com.example.Annotation1', 'AnnotationValue')",
+      ),
+    );
   });
 
   test('introspect xml - annotation missing fields', () {
     expect(
-        () => parseDBusIntrospectXml(
-            '<node><interface name="com.example.Test"><property name="Count" type="u"><annotation/></property></interface></node>'),
-        throwsFormatException);
+      () => parseDBusIntrospectXml(
+        '<node><interface name="com.example.Test"><property name="Count" type="u"><annotation/></property></interface></node>',
+      ),
+      throwsFormatException,
+    );
     expect(
-        () => parseDBusIntrospectXml(
-            '<node><interface name="com.example.Test"><property name="Count" type="u"><annotation name="com.example.Test.Name"/></property></interface></node>'),
-        throwsFormatException);
+      () => parseDBusIntrospectXml(
+        '<node><interface name="com.example.Test"><property name="Count" type="u"><annotation name="com.example.Test.Name"/></property></interface></node>',
+      ),
+      throwsFormatException,
+    );
     expect(
-        () => parseDBusIntrospectXml(
-            '<node><interface name="com.example.Test"><property name="Count" type="u"><annotation value="AnnotationValue"/></property></interface></node>'),
-        throwsFormatException);
+      () => parseDBusIntrospectXml(
+        '<node><interface name="com.example.Test"><property name="Count" type="u"><annotation value="AnnotationValue"/></property></interface></node>',
+      ),
+      throwsFormatException,
+    );
   });
 
   test('server invalid addresses', () async {
     var server = DBusServer();
     expect(
-        () => server.listenAddress(DBusAddress('invalid:')), throwsException);
+      () => server.listenAddress(DBusAddress('invalid:')),
+      throwsException,
+    );
     expect(() => server.listenAddress(DBusAddress('unix:')), throwsException);
-    expect(() => server.listenAddress(DBusAddress('unix:runtime=INVALID')),
-        throwsException);
+    expect(
+      () => server.listenAddress(DBusAddress('unix:runtime=INVALID')),
+      throwsException,
+    );
     expect(() => server.listenAddress(DBusAddress('tcp:')), throwsException);
     expect(
-        () => server
-            .listenAddress(DBusAddress('tcp:host=com.example,family=INVALID')),
-        throwsException);
+      () => server.listenAddress(
+        DBusAddress('tcp:host=com.example,family=INVALID'),
+      ),
+      throwsException,
+    );
     expect(
-        () => server
-            .listenAddress(DBusAddress('tcp:host=com.example,port=INVALID')),
-        throwsException);
+      () => server.listenAddress(
+        DBusAddress('tcp:host=com.example,port=INVALID'),
+      ),
+      throwsException,
+    );
   });
 
   for (var name in [
@@ -5715,15 +7244,16 @@ void main() {
     'signal-single-arg',
     'signal-multiple-args',
     'signals',
-    'multiple-interfaces'
+    'multiple-interfaces',
   ]) {
     test('code generator - client - $name', () async {
       var xml = await File('test/generated-code/$name.in').readAsString();
       var node = parseDBusIntrospectXml(xml);
       var generator = DBusCodeGenerator(node);
       var code = generator.generateClientSource();
-      var expectedCode =
-          await File('test/generated-code/$name.client.out').readAsString();
+      var expectedCode = await File(
+        'test/generated-code/$name.client.out',
+      ).readAsString();
       expect(code, equals(expectedCode));
     });
 
@@ -5732,38 +7262,46 @@ void main() {
       var node = parseDBusIntrospectXml(xml);
       var generator = DBusCodeGenerator(node);
       var code = generator.generateServerSource();
-      var expectedCode =
-          await File('test/generated-code/$name.server.out').readAsString();
+      var expectedCode = await File(
+        'test/generated-code/$name.server.out',
+      ).readAsString();
       expect(code, equals(expectedCode));
     });
   }
 
   test('code generator - comment', () async {
     var generator = DBusCodeGenerator(
-        DBusIntrospectNode(name: '/com/example/Object'),
-        comment: 'This is great code.\nIt is the best code.');
+      DBusIntrospectNode(name: '/com/example/Object'),
+      comment: 'This is great code.\nIt is the best code.',
+    );
     expect(
-        generator.generateClientSource(),
-        equals('// This is great code.\n'
-            '// It is the best code.\n'
-            '\n'
-            'import \'dart:io\';\n'
-            'import \'package:dbus/dbus.dart\';\n'
-            '\n'
-            'class ComExampleObject extends DBusRemoteObject {\n'
-            '  ComExampleObject(DBusClient client, String destination, {DBusObjectPath path = const DBusObjectPath.unchecked(\'/com/example/Object\')}) : super(client, name: destination, path: path);\n'
-            '}\n'));
+      generator.generateClientSource(),
+      equals(
+        '// This is great code.\n'
+        '// It is the best code.\n'
+        '\n'
+        'import \'dart:io\';\n'
+        'import \'package:dbus/dbus.dart\';\n'
+        '\n'
+        'class ComExampleObject extends DBusRemoteObject {\n'
+        '  ComExampleObject(DBusClient client, String destination, {DBusObjectPath path = const DBusObjectPath.unchecked(\'/com/example/Object\')}) : super(client, name: destination, path: path);\n'
+        '}\n',
+      ),
+    );
     expect(
-        generator.generateServerSource(),
-        equals('// This is great code.\n'
-            '// It is the best code.\n'
-            '\n'
-            'import \'dart:io\';\n'
-            'import \'package:dbus/dbus.dart\';\n'
-            '\n'
-            'class ComExampleObject extends DBusObject {\n'
-            '  /// Creates a new object to expose on [path].\n'
-            '  ComExampleObject({DBusObjectPath path = const DBusObjectPath.unchecked(\'/com/example/Object\')}) : super(path);\n'
-            '}\n'));
+      generator.generateServerSource(),
+      equals(
+        '// This is great code.\n'
+        '// It is the best code.\n'
+        '\n'
+        'import \'dart:io\';\n'
+        'import \'package:dbus/dbus.dart\';\n'
+        '\n'
+        'class ComExampleObject extends DBusObject {\n'
+        '  /// Creates a new object to expose on [path].\n'
+        '  ComExampleObject({DBusObjectPath path = const DBusObjectPath.unchecked(\'/com/example/Object\')}) : super(path);\n'
+        '}\n',
+      ),
+    );
   });
 }


### PR DESCRIPTION
Replace deprecated XmlName(...) usages with XmlName.parts('...'), simplify element creation via XmlElement.tag(...), and fix analyzer errors by marking FFI Struct subclasses as final and removing unnecessary non-null assertions.

I also upgraded the min version to dart 3.11 to match the xml min sdk