### PR TITLE
Allow xml 7

### DIFF
--- a/lib/src/dbus_introspect.dart
+++ b/lib/src/dbus_introspect.dart
@@ -1,3 +1,6 @@
+// This is required to allow xml 7 while also allowing xml 6
+// ignore_for_file: deprecated_member_use
+
 import 'dbus_value.dart';
 import 'package:xml/xml.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   args: ^2.0.0
   ffi: ^2.0.0
   meta: ^1.3.0
-  xml: ^6.6.1
+  xml: ">=6.6.1 <8.0.0"
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
See #402.

This allows xml 7 while also allowing xml 6. This also doesn't need any formatting/env changes. Currently only lint is outdated (maybe i will make a new pr for that).

I also ignore deprecated methods to let analyze be green.